### PR TITLE
Change 'just passed' to 'just past'

### DIFF
--- a/step02/index.textile
+++ b/step02/index.textile
@@ -286,7 +286,7 @@ If you purchased a limit switch kit with your X-Carve, click below to mount your
 | 25284-09 | Hex Nuts M2 | 2 |
 | 30555-02 | Split Lock Washer M2 | 2 |
 
-Put the lock washers onto the screws and insert them through the switch and into the holes on the X Carriage (they're on the right side if you're looking at the motor). Use a pair of pliers and a screwdriver to snug these down just passed finger tight.
+Put the lock washers onto the screws and insert them through the switch and into the holes on the X Carriage (they're on the right side if you're looking at the motor). Use a pair of pliers and a screwdriver to snug these down just past finger tight.
 
 !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/858/original/1471.jpg?1427918942! !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/857/original/1474.jpg?1427918941! !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/856/original/1479.jpg?1427918940! !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/855/original/1482.jpg?1427918939!
       </div>

--- a/step03/index.textile
+++ b/step03/index.textile
@@ -257,7 +257,7 @@ If you purchased a limit switch kit with your X-Carve, click below to mount your
 | 25284-09 | Hex Nuts M2 | 2 |
 | 30555-02 | Split Lock Washer M2 | 2 |
 
-Put the lock washers onto the screws and insert them through the switch and into the holes on the left Y-Plate. Use a pair of pliers and a screwdriver to snug these down just passed finger tight.
+Put the lock washers onto the screws and insert them through the switch and into the holes on the left Y-Plate. Use a pair of pliers and a screwdriver to snug these down just past finger tight.
 
 !https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/862/original/1485.jpg?1427919741! 
 

--- a/step07/index.textile
+++ b/step07/index.textile
@@ -122,6 +122,6 @@ p=. !https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_up
 | 30544-03 | Pan Head Screw M2 x 10mm | 2 |
 | 30555-02 | Split Lock Washer M2 | 2 |
 
-Put the lock washers onto the screws and insert them through the switch and into the holes on the side of the Z-Plate. The holes are threaded, simply tighten the screws just passed finger tight.
+Put the lock washers onto the screws and insert them through the switch and into the holes on the side of the Z-Plate. The holes are threaded, simply tighten the screws just past finger tight.
 <div class="row"> !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/863/original/1197.jpg?1427920758! !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/864/original/1204.jpg?1427920759! !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/865/original/1207.jpg?1427920760! !(thumbnail col-md-3)https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/866/original/1208.jpg?1427920761!
 </div>

--- a/step14/index.textile
+++ b/step14/index.textile
@@ -203,7 +203,7 @@ Place the top of the gShield enclosure on to the bottom.
 
 p=. !https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/878/original/1141.jpg?1427991581!
 
-There are two M3 x 6mm screws that couple the top and bottom. Thread them into the enclosure by hand and tighten them just passed finger tight with your wrench.
+There are two M3 x 6mm screws that couple the top and bottom. Thread them into the enclosure by hand and tighten them just past finger tight with your wrench.
 
 p=. !https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/877/original/1143.jpg?1427991580!
 


### PR DESCRIPTION
When describing a position, it should be spelled 'past' not 'passed'
