### PR TITLE
Update index.md

### DIFF
--- a/1000mm/step2a/5motors/index.md
+++ b/1000mm/step2a/5motors/index.md
@@ -83,7 +83,7 @@ diagram: "motors1.jpg"
 
 <h3>Attach NEMA 23 Motor to Plate</h3>
 
-In this step, we'll be attaching the motors to the Y plates. The motor pulleys are already crimped to the shafts of the motors so you won't have to worry about attaching or adjusting them. You'll need two of the X-Axis motors, eight M5x16mm socket head cap screws, and eight M5 nylock nuts.
+In this step, we'll be attaching the motors to the Y plates. The motor pulleys are already crimped to the shafts of the motors so you won't have to worry about attaching or adjusting them. You'll need two of the motors, eight M5x16mm socket head cap screws, and eight M5 nylock nuts.
 
 First, position the motor hub in the large hole on the gantry plate. Make sure that the white socket for the electrical connection is facing the rear of the gantry plate (it should be closest to the holes for the makerslide).
 <img src="../../step2/photo/jpfs_DSC2602.jpg">


### PR DESCRIPTION
deleted "X-Axis" The first paragraph says "You’ll need two of the X-Axis motors"  I spent 5 minutes trying to find motors marked "X-Axis", but they all look the same.  I suggest saying "You'll need two of the motors."

For John to review