### PR TITLE
Hypen to underscore

### DIFF
--- a/1000mm/index.md
+++ b/1000mm/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: 'Welcome!'
-step-number: 1
+step_number: 1
 permalink: /1000mm/
 next-step: /1000mm/step1/
 next-step-title: 'Work Area'

--- a/1000mm/index.md
+++ b/1000mm/index.md
@@ -1,23 +1,23 @@
 ---
 layout: default1000mm
-title: "Welcome!"
+title: 'Welcome!'
 step-number: 1
 permalink: /1000mm/
 next-step: /1000mm/step1/
-next-step-title: "Work Area"
+next-step-title: 'Work Area'
 ---
 
 <img src="../x-carve-main.jpg">
 
-Congratulations!  You've just taken one of your first steps into the world of 3D Carving!  This guide will take you through the steps of building your very own X-Carve 3D Carver! We've tried to make it as easy as possible to get you from unpacking your parts to carving.  We've laid out the instructions starting from the bottom of the machine to the top, and we will cover everything from machine assembly to computer setup.
+Congratulations! You've just taken one of your first steps into the world of 3D Carving! This guide will take you through the steps of building your very own X-Carve 3D Carver! We've tried to make it as easy as possible to get you from unpacking your parts to carving. We've laid out the instructions starting from the bottom of the machine to the top, and we will cover everything from machine assembly to computer setup.
 
-This is a do-it-yourself 3D carving kit: the more time and attention you put into assembling your machine, the better it will perform.  If you run into any trouble during assembly or carving you can find further help from the wonderful community on the forum, our support center which is continuously growing with articles and tutorials, and as always you can reach our customer success team through our [support center](https://inventables.desk.com/) or by phone at 312 775 7009.
+This is a do-it-yourself 3D carving kit: the more time and attention you put into assembling your machine, the better it will perform. If you run into any trouble during assembly or carving you can find further help from the wonderful community on the forum, our support center which is continuously growing with articles and tutorials, and as always you can reach our customer success team through our [support center](https://inventables.desk.com/) or by phone at 312 775 7009.
 
 The X-Carve is open source hardware. We have 3D models and drawings available in a GrabCAD repository <a href="https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcojYwyy_VqboQQ-9hKBJrjS3zGaGuue8sfnqRNxGI9WQS">here</a>.
 
 <h2>Recommended Tools</h2>
 
-If you purchased a tool kit with your machine, most of these should be included with the exception of power tools 
+If you purchased a tool kit with your machine, most of these should be included with the exception of power tools
 
 - 7mm wrench or socket
 - 8mm wrench or socket
@@ -33,1669 +33,886 @@ If you purchased a tool kit with your machine, most of these should be included 
 
 <h2>Bill of Materials</h2>
 <div class="bom">
-<div class="panel-group" id="core-components-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#core-components-accordion" href="#core-components" aria-expanded="false" aria-controls="core-components" style="color:#fff;background:#383838" class="panel-heading" role="tab" id="core-components-header">
-<h4 class="panel-title">
-<strong>Core Components</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="core-components" class="panel-collapse collapse" role="tabpanel" aria-labelledby="core-components-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #383838" colspan="3">
-      <b>Core Components Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30524-01
-    </td>
-    <td>
-      MakerSlide End Plate
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30525-01
-    </td>
-    <td>
-      Gantry Side Plate
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30526-01
-    </td>
-    <td>
-      Belt Clip
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30677-01
-    </td>
-    <td>
-      Belt Sleeve Clip
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30396-02
-    </td>
-    <td>
-      ACME Lead Screw
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25195-07
-    </td>
-    <td>
-      Eccentric Spacer 0.200" Long
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25195-08
-    </td>
-    <td>
-      Eccentric Spacer 0.375" Long
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30534-01
-    </td>
-    <td>
-      Z Axis Motor Plate
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-12
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      18
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26054-04
-    </td>
-    <td>
-      Aluminum GT2 Pulley 20T 8mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25280-03
-    </td>
-    <td>
-      Delrin Nut ACME 3/8-12
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30547-01
-    </td>
-    <td>
-      GT2 Belt Closed Loop, 80T
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25312-23
-    </td>
-    <td>
-      Aluminum Spacer 5.1mm ID 9.5mm OD 9.5mm LG
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-11
-    </td>
-    <td>
-      Flat Washer M8
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30545-01
-    </td>
-    <td>
-      X Carriage Extrusion
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25142-09
-    </td>
-    <td>
-      MakerSlide 200mm Tapped Black
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25203-01
-    </td>
-    <td>
-      V Wheel Assembly
-    </td>
-    <td>
-      20
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25197-01
-    </td>
-    <td>
-      Smooth Idler Pulley Assembly
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-33
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 8
-    </td>
-    <td>
-      16
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-35
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-38
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      16
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-46
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-43
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 25
-    </td>
-    <td>
-      11
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-49
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 30
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-48
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 40
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30169-01
-    </td>
-    <td>
-      Flanged Bearing, 8mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30552-05
-    </td>
-    <td>
-      Flat Head Screw M5 x 35
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-12
-    </td>
-    <td>
-      M5 Flat Washer
-    </td>
-    <td>
-      26
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-09
-    </td>
-    <td>
-      Nylon Insert Lock Nut M5
-    </td>
-    <td>
-      41
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-05
-    </td>
-    <td>
-      Nylon Insert Lock Nut M6
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-54
-    </td>
-    <td>
-      Socket Head Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-52
-    </td>
-    <td>
-      Socket Head Screw M5 x 16
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-53
-    </td>
-    <td>
-      Socket Head Screw M5 x 20
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30711-01
-    </td>
-    <td>
-      Lubricant
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
-<h4 class="panel-title">
-<strong>Rail Size</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="rail-size" class="panel-collapse collapse" role="tabpanel" aria-labelledby="rail-size-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#000;background: #FFFFFF" colspan="3">
-      <b>1000mm Rail Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-10
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26018-01
-    </td>
-    <td>
-      Extrusion Bracket (Gusset)
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-02
-    </td>
-    <td>
-      X-Carve Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26053-01
-    </td>
-    <td>
-      GT2 Belting - Open Ended (feet)
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-02
-    </td>
-    <td>
-      Aluminum Extrusion 20mm × 20mm Black 1000mm Lg
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-04
-    </td>
-    <td>
-      Aluminum Extrusion 20mm × 20mm Black 958mm Lg
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25142-11
-    </td>
-    <td>
-      MakerSlide 1000mm Tapped Black
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30678-03
-    </td>
-    <td>
-      MakerSlide Extra Wide 1000mm Tapped Black
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-36
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="motors-and-wiring-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#motors-and-wiring-accordion" href="#motors-and-wiring" aria-expanded="false" aria-controls="motors-and-wiring" style="color:#fff;background:#CC3440" class="panel-heading" role="tab" id="motors-and-wiring-header">
-<h4 class="panel-title">
-<strong>Motors and Wiring</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="motors-and-wiring" class="panel-collapse collapse" role="tabpanel" aria-labelledby="motors-and-wiring-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #CC3440" colspan="3">
-      <b>1000mm Motor and Wiring Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25311-06
-    </td>
-    <td>
-      Stepper Motor - NEMA 23
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-09
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 97 in long (X-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-10
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 42 in long (Y1-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-11
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 89 in long (Y2-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-12
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 97 in long (Z-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="drag-chain-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#drag-chain-accordion" href="#drag-chain" aria-expanded="false" aria-controls="drag-chain" style="color:#fff;background:#8A52A1" class="panel-heading" role="tab" id="drag-chain-header">
-<h4 class="panel-title">
-<strong>Drag Chain</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="drag-chain" class="panel-collapse collapse" role="tabpanel" aria-labelledby="drag-chain-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #8A52A1" colspan="3">
-      <b>1000mm Drag Chain Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30527-05
-    </td>
-    <td>
-      Drag Chain Bracket
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30527-06
-    </td>
-    <td>
-      Drag Chain Bracket
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30680-01
-    </td>
-    <td>
-      Zip Tie Mount
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26016-03
-    </td>
-    <td>
-      T-Nut M5 Post Assembly
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30681-01
-    </td>
-    <td>
-      Drag Chain Support Arm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30331-13
-    </td>
-    <td>
-      Drag Chain 18x25 21 Links w/ Custom Ends
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25986-03
-    </td>
-    <td>
-      Cable Tie 4" (100 Pack)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-09
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 1000mm Tapped
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-44
-    </td>
-    <td>
-      Button Head Cap Screw M4 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-31
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 6
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-46
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30554-06
-    </td>
-    <td>
-      Flat Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30554-07
-    </td>
-    <td>
-      Flat Head Cap Screw M5 x 12
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-08
-    </td>
-    <td>
-      Nylon Insert Lock Nut M4
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-10
-    </td>
-    <td>
-      Nylon Insert Lock Nut M5
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="home-switch-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#home-switch-accordion" href="#home-switch" aria-expanded="false" aria-controls="home-switch" style="color:#fff;background:#F47B44" class="panel-heading" role="tab" id="home-switch-header">
-<h4 class="panel-title">
-<strong>Home Switch</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="home-switch" class="panel-collapse collapse" role="tabpanel" aria-labelledby="home-switch-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #F47B44" colspan="3">
-      <b>1000mm Homing Switch Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30557-02
-    </td>
-    <td>
-      Microswitch
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26016-03
-    </td>
-    <td>
-      Post-Assembly M5 T-Slot Nuts
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-07
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 95"Lg X-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-08
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 50"Lg Y-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-09
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 95"Lg Z-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25312-25
-    </td>
-    <td>
-      Spacer 5.1mm ID 9.5mm 10.5mm Lg Aluminum
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25284-12
-    </td>
-    <td>
-      Hex Nut M2x0.4
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-07
-    </td>
-    <td>
-      Hex Nut M3 Nylon Locking
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-56
-    </td>
-    <td>
-      Socket Head Screw M2 x 10
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-57
-    </td>
-    <td>
-      Socket Head Screw M2 x 14
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-44
-    </td>
-    <td>
-      Socket Head Screw M3 x 20
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-51
-    </td>
-    <td>
-      Socket Head Screw M5 x 16
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30555-03
-    </td>
-    <td>
-      Washer, Split Lock M2 Stainless
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="waste-board-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#waste-board-accordion" href="#waste-board" aria-expanded="false" aria-controls="waste-board" style="color:#fff;background:#0a91d1" class="panel-heading" role="tab" id="waste-board-header">
-<h4 class="panel-title">
-<strong>Waste Board</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="waste-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="waste-board-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #0a91d1" colspan="3">
-      <b>1000mm Waste Board Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-11
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      14
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30537-01
-    </td>
-    <td>
-      1000mm Waste Board
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30517-09
-    </td>
-    <td>
-      Threaded Insert M5 x 10
-    </td>
-    <td>
-      144
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-42
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 20
-    </td>
-    <td>
-      14
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="side-board-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#side-board-accordion" href="#side-board" aria-expanded="false" aria-controls="side-board" style="color:#fff;background:#9D9FA2" class="panel-heading" role="tab" id="side-board-header">
-<h4 class="panel-title">
-<strong>Side Board</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="side-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="side-board-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #9D9FA2" colspan="3">
-      <b>1000mm Side Board Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30684-01
-    </td>
-    <td>
-      Extrusion Connection Bracket
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-13
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      21
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26018-01
-    </td>
-    <td>
-      Cast Corner Bracket, Clear
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30517-11
-    </td>
-    <td>
-      Threaded Insert M5
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30685-03
-    </td>
-    <td>
-      Side Board, X-Carve 1000mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-10
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 250mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-04
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 958mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-34
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 8
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-37
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-41
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-47
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="spindle-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#spindle-accordion" href="#spindle" aria-expanded="false" aria-controls="spindle" style="color:#fff;background:#42a44e" class="panel-heading" role="tab" id="spindle-header">
-<h4 class="panel-title">
-<strong>Spindle</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="spindle" class="panel-collapse collapse" role="tabpanel" aria-labelledby="spindle-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>110V DeWalt 611 Spindle and Mount</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30621-01
-    </td>
-    <td>
-      DeWalt 611 Router
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>240V DeWalt 611 Spindle and Mount</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30621-02
-    </td>
-    <td>
-      240V DeWalt 26200 router
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>X-Carve DeWalt 611 Spindle Mount (Does Not Include Spindle)</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>Bosch Colt Spindle Mount Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30287-01
-    </td>
-    <td>
-      Spindle Mounting Plate
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30329-03
-    </td>
-    <td>
-      Bosch Colt Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30549-01
-    </td>
-    <td>
-      Rubber Inventables Sticker
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-18
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-08
-    </td>
-    <td>
-      Flat Washer M5
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-37
-    </td>
-    <td>
-      Socket Head Screw M5 x 20
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-38
-    </td>
-    <td>
-      Socket Head Screw M5 x 25
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30555-01
-    </td>
-    <td>
-      Split Lockwashers M5
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="z-probe-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#z-probe-accordion" href="#z-probe" aria-expanded="false" aria-controls="z-probe" style="color:#fff;background:#000" class="panel-heading" role="tab" id="z-probe-header">
-<h4 class="panel-title">
-<strong>Z-Probe</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="z-probe" class="panel-collapse collapse" role="tabpanel" aria-labelledby="z-probe-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #000" colspan="3">
-      <b>Z-Probe</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30611-02
-    </td>
-    <td>
-      Z-Probe Kit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
+  <div class="panel-group" id="core-components-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#core-components-accordion" href="#core-components" aria-expanded="false" aria-controls="core-components" style="color:#fff;background:#383838" class="panel-heading" role="tab" id="core-components-header">
+        <h4 class="panel-title">
+          <strong>Core Components</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="core-components" class="panel-collapse collapse" role="tabpanel" aria-labelledby="core-components-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #383838" colspan="3">
+                <b>Core Components Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30524-01</td>
+              <td>MakerSlide End Plate</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>30525-01</td>
+              <td>Gantry Side Plate</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30526-01</td>
+              <td>Belt Clip</td>
+              <td>6</td>
+            </tr>
+            <tr>
+              <td>30677-01</td>
+              <td>Belt Sleeve Clip</td>
+              <td>6</td>
+            </tr>
+            <tr>
+              <td>30396-02</td>
+              <td>ACME Lead Screw</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25195-07</td>
+              <td>Eccentric Spacer 0.200" Long</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>25195-08</td>
+              <td>Eccentric Spacer 0.375" Long</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30534-01</td>
+              <td>Z Axis Motor Plate</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25281-12</td>
+              <td>T-Slot Nut M5 Pre-Assembly</td>
+              <td>18</td>
+            </tr>
+            <tr>
+              <td>26054-04</td>
+              <td>Aluminum GT2 Pulley 20T 8mm</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25280-03</td>
+              <td>Delrin Nut ACME 3/8-12</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30547-01</td>
+              <td>GT2 Belt Closed Loop, 80T</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25312-23</td>
+              <td>Aluminum Spacer 5.1mm ID 9.5mm OD 9.5mm LG</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>25287-11</td>
+              <td>Flat Washer M8</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30545-01</td>
+              <td>X Carriage Extrusion</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25142-09</td>
+              <td>MakerSlide 200mm Tapped Black</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25203-01</td>
+              <td>V Wheel Assembly</td>
+              <td>20</td>
+            </tr>
+            <tr>
+              <td>25197-01</td>
+              <td>Smooth Idler Pulley Assembly</td>
+              <td>6</td>
+            </tr>
+            <tr>
+              <td>25286-33</td>
+              <td>Button Head Cap Screw M5 x 8</td>
+              <td>16</td>
+            </tr>
+            <tr>
+              <td>25286-35</td>
+              <td>Button Head Cap Screw M5 x 10</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>25286-38</td>
+              <td>Button Head Cap Screw M5 x 12</td>
+              <td>16</td>
+            </tr>
+            <tr>
+              <td>25286-46</td>
+              <td>Button Head Cap Screw M5 x 14</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25286-43</td>
+              <td>Button Head Cap Screw M5 x 25</td>
+              <td>11</td>
+            </tr>
+            <tr>
+              <td>25286-49</td>
+              <td>Button Head Cap Screw M5 x 30</td>
+              <td>12</td>
+            </tr>
+            <tr>
+              <td>25286-48</td>
+              <td>Button Head Cap Screw M5 x 40</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>30169-01</td>
+              <td>Flanged Bearing, 8mm</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30552-05</td>
+              <td>Flat Head Screw M5 x 35</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25287-12</td>
+              <td>M5 Flat Washer</td>
+              <td>26</td>
+            </tr>
+            <tr>
+              <td>30265-09</td>
+              <td>Nylon Insert Lock Nut M5</td>
+              <td>41</td>
+            </tr>
+            <tr>
+              <td>30265-05</td>
+              <td>Nylon Insert Lock Nut M6</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-54</td>
+              <td>Socket Head Screw M5 x 10</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>25285-52</td>
+              <td>Socket Head Screw M5 x 16</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>25285-53</td>
+              <td>Socket Head Screw M5 x 20</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>30711-01</td>
+              <td>Lubricant</td>
+              <td>1</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
+        <h4 class="panel-title">
+          <strong>Rail Size</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="rail-size" class="panel-collapse collapse" role="tabpanel" aria-labelledby="rail-size-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#000;background: #FFFFFF" colspan="3">
+                <b>1000mm Rail Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>25281-10</td>
+              <td>T-Slot Nut M5 Pre-Assembly</td>
+              <td>12</td>
+            </tr>
+            <tr>
+              <td>26018-01</td>
+              <td>Extrusion Bracket (Gusset)</td>
+              <td>6</td>
+            </tr>
+            <tr>
+              <td>30558-02</td>
+              <td>X-Carve Label</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>26053-01</td>
+              <td>GT2 Belting - Open Ended (feet)</td>
+              <td>12</td>
+            </tr>
+            <tr>
+              <td>26049-02</td>
+              <td>Aluminum Extrusion 20mm × 20mm Black 1000mm Lg</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>26049-04</td>
+              <td>Aluminum Extrusion 20mm × 20mm Black 958mm Lg</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>25142-11</td>
+              <td>MakerSlide 1000mm Tapped Black</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30678-03</td>
+              <td>MakerSlide Extra Wide 1000mm Tapped Black</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25286-36</td>
+              <td>Button Head Cap Screw M5 x 10</td>
+              <td>12</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="motors-and-wiring-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#motors-and-wiring-accordion" href="#motors-and-wiring" aria-expanded="false" aria-controls="motors-and-wiring" style="color:#fff;background:#CC3440" class="panel-heading" role="tab" id="motors-and-wiring-header">
+        <h4 class="panel-title">
+          <strong>Motors and Wiring</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="motors-and-wiring" class="panel-collapse collapse" role="tabpanel" aria-labelledby="motors-and-wiring-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #CC3440" colspan="3">
+                <b>1000mm Motor and Wiring Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>25311-06</td>
+              <td>Stepper Motor - NEMA 23</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>30679-09</td>
+              <td>Cable Assembly, Stepper Motor 97 in long (X-Axis)</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30679-10</td>
+              <td>Cable Assembly, Stepper Motor 42 in long (Y1-Axis)</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30679-11</td>
+              <td>Cable Assembly, Stepper Motor 89 in long (Y2-Axis)</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30679-12</td>
+              <td>Cable Assembly, Stepper Motor 97 in long (Z-Axis)</td>
+              <td>1</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="drag-chain-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#drag-chain-accordion" href="#drag-chain" aria-expanded="false" aria-controls="drag-chain" style="color:#fff;background:#8A52A1" class="panel-heading" role="tab" id="drag-chain-header">
+        <h4 class="panel-title">
+          <strong>Drag Chain</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="drag-chain" class="panel-collapse collapse" role="tabpanel" aria-labelledby="drag-chain-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #8A52A1" colspan="3">
+                <b>1000mm Drag Chain Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30527-05</td>
+              <td>Drag Chain Bracket</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30527-06</td>
+              <td>Drag Chain Bracket</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30680-01</td>
+              <td>Zip Tie Mount</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>26016-03</td>
+              <td>T-Nut M5 Post Assembly</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>30681-01</td>
+              <td>Drag Chain Support Arm</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30331-13</td>
+              <td>Drag Chain 18x25 21 Links w/ Custom Ends</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25986-03</td>
+              <td>Cable Tie 4" (100 Pack)</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>26049-09</td>
+              <td>Extrusion T-Slot 20x20 x 1000mm Tapped</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25286-44</td>
+              <td>Button Head Cap Screw M4 x 10</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>25286-31</td>
+              <td>Button Head Cap Screw M5 x 6</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25286-46</td>
+              <td>Button Head Cap Screw M5 x 14</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30554-06</td>
+              <td>Flat Head Cap Screw M5 x 10</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>30554-07</td>
+              <td>Flat Head Cap Screw M5 x 12</td>
+              <td>6</td>
+            </tr>
+            <tr>
+              <td>30265-08</td>
+              <td>Nylon Insert Lock Nut M4</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30265-10</td>
+              <td>Nylon Insert Lock Nut M5</td>
+              <td>6</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="home-switch-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#home-switch-accordion" href="#home-switch" aria-expanded="false" aria-controls="home-switch" style="color:#fff;background:#F47B44" class="panel-heading" role="tab" id="home-switch-header">
+        <h4 class="panel-title">
+          <strong>Home Switch</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="home-switch" class="panel-collapse collapse" role="tabpanel" aria-labelledby="home-switch-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #F47B44" colspan="3">
+                <b>1000mm Homing Switch Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30557-02</td>
+              <td>Microswitch</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>26016-03</td>
+              <td>Post-Assembly M5 T-Slot Nuts</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30682-07</td>
+              <td>Cable Assembly, 2C Lugs Ferrules 95"Lg X-Limit</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30682-08</td>
+              <td>Cable Assembly, 2C Lugs Ferrules 50"Lg Y-Limit</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30682-09</td>
+              <td>Cable Assembly, 2C Lugs Ferrules 95"Lg Z-Limit</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25312-25</td>
+              <td>Spacer 5.1mm ID 9.5mm 10.5mm Lg Aluminum</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25284-12</td>
+              <td>Hex Nut M2x0.4</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30265-07</td>
+              <td>Hex Nut M3 Nylon Locking</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-56</td>
+              <td>Socket Head Screw M2 x 10</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25285-57</td>
+              <td>Socket Head Screw M2 x 14</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>25285-44</td>
+              <td>Socket Head Screw M3 x 20</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-51</td>
+              <td>Socket Head Screw M5 x 16</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30555-03</td>
+              <td>Washer, Split Lock M2 Stainless</td>
+              <td>6</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="waste-board-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#waste-board-accordion" href="#waste-board" aria-expanded="false" aria-controls="waste-board" style="color:#fff;background:#0a91d1" class="panel-heading" role="tab" id="waste-board-header">
+        <h4 class="panel-title">
+          <strong>Waste Board</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="waste-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="waste-board-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #0a91d1" colspan="3">
+                <b>1000mm Waste Board Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>25281-11</td>
+              <td>T-Slot Nut M5 Pre-Assembly</td>
+              <td>14</td>
+            </tr>
+            <tr>
+              <td>30537-01</td>
+              <td>1000mm Waste Board</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30517-09</td>
+              <td>Threaded Insert M5 x 10</td>
+              <td>144</td>
+            </tr>
+            <tr>
+              <td>25286-42</td>
+              <td>Button Head Cap Screw M5 x 20</td>
+              <td>14</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="side-board-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#side-board-accordion" href="#side-board" aria-expanded="false" aria-controls="side-board" style="color:#fff;background:#9D9FA2" class="panel-heading" role="tab" id="side-board-header">
+        <h4 class="panel-title">
+          <strong>Side Board</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="side-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="side-board-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #9D9FA2" colspan="3">
+                <b>1000mm Side Board Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30684-01</td>
+              <td>Extrusion Connection Bracket</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25281-13</td>
+              <td>T-Slot Nut M5 Pre-Assembly</td>
+              <td>21</td>
+            </tr>
+            <tr>
+              <td>26018-01</td>
+              <td>Cast Corner Bracket, Clear</td>
+              <td>4</td>
+            </tr>
+            <tr>
+              <td>30517-11</td>
+              <td>Threaded Insert M5</td>
+              <td>12</td>
+            </tr>
+            <tr>
+              <td>30685-03</td>
+              <td>Side Board, X-Carve 1000mm</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>26049-10</td>
+              <td>Extrusion T-Slot 20x20 x 250mm</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>26049-04</td>
+              <td>Extrusion T-Slot 20x20 x 958mm</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25286-34</td>
+              <td>Button Head Cap Screw M5 x 8</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>25286-37</td>
+              <td>Button Head Cap Screw M5 x 10</td>
+              <td>8</td>
+            </tr>
+            <tr>
+              <td>25286-41</td>
+              <td>Button Head Cap Screw M5 x 12</td>
+              <td>5</td>
+            </tr>
+            <tr>
+              <td>25286-47</td>
+              <td>Button Head Cap Screw M5 x 14</td>
+              <td>12</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="spindle-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#spindle-accordion" href="#spindle" aria-expanded="false" aria-controls="spindle" style="color:#fff;background:#42a44e" class="panel-heading" role="tab" id="spindle-header">
+        <h4 class="panel-title">
+          <strong>Spindle</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="spindle" class="panel-collapse collapse" role="tabpanel" aria-labelledby="spindle-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #42a44e" colspan="3">
+                <b>110V DeWalt 611 Spindle and Mount</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30621-01</td>
+              <td>DeWalt 611 Router</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30610-01</td>
+              <td>X-Carve DeWalt 611 Spindle Mount</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-55</td>
+              <td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>25286-45</td>
+              <td>Button Head Cap Screw M5 × 16mm</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30558-01</td>
+              <td>Inventables Label</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30662-01</td>
+              <td>1/4" to 1/8" Collet Adapter</td>
+              <td>1</td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td style="color:#fff;background: #42a44e" colspan="3">
+                <b>240V DeWalt 611 Spindle and Mount</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30621-02</td>
+              <td>240V DeWalt 26200 router</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30610-01</td>
+              <td>X-Carve DeWalt 611 Spindle Mount</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-55</td>
+              <td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>25286-45</td>
+              <td>Button Head Cap Screw M5 × 16mm</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30558-01</td>
+              <td>Inventables Label</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30662-01</td>
+              <td>1/4" to 1/8" Collet Adapter</td>
+              <td>1</td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td style="color:#fff;background: #42a44e" colspan="3">
+                <b>X-Carve DeWalt 611 Spindle Mount (Does Not Include Spindle)</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30610-01</td>
+              <td>X-Carve DeWalt 611 Spindle Mount</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-55</td>
+              <td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+              <td>3</td>
+            </tr>
+            <tr>
+              <td>30558-01</td>
+              <td>Inventables Label</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25286-45</td>
+              <td>Button Head Cap Screw M5 × 16mm</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>30662-01</td>
+              <td>1/4" to 1/8" Collet Adapter</td>
+              <td>1</td>
+            </tr>
+          </table>
+          <table>
+            <tr>
+              <td style="color:#fff;background: #42a44e" colspan="3">
+                <b>Bosch Colt Spindle Mount Kit</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30287-01</td>
+              <td>Spindle Mounting Plate</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30329-03</td>
+              <td>Bosch Colt Spindle Mount</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30549-01</td>
+              <td>Rubber Inventables Sticker</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25286-18</td>
+              <td>Button Head Cap Screw M5 x 10</td>
+              <td>2</td>
+            </tr>
+            <tr>
+              <td>25287-08</td>
+              <td>Flat Washer M5</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-37</td>
+              <td>Socket Head Screw M5 x 20</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>25285-38</td>
+              <td>Socket Head Screw M5 x 25</td>
+              <td>1</td>
+            </tr>
+            <tr>
+              <td>30555-01</td>
+              <td>Split Lockwashers M5</td>
+              <td>1</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="panel-group" id="z-probe-accordion" role="tablist" aria-multiselectable="true">
+    <div class="panel panel-default">
+      <div data-toggle="collapse" data-parent="#z-probe-accordion" href="#z-probe" aria-expanded="false" aria-controls="z-probe" style="color:#fff;background:#000" class="panel-heading" role="tab" id="z-probe-header">
+        <h4 class="panel-title">
+          <strong>Z-Probe</strong>
+        </h4>
+        <div class="expand-icons">
+          <i class="fa fa-plus"></i>
+          <i class="fa fa-minus"></i>
+        </div>
+      </div>
+      <div id="z-probe" class="panel-collapse collapse" role="tabpanel" aria-labelledby="z-probe-header">
+        <div class="panel-body">
+          <table>
+            <tr>
+              <td style="color:#fff;background: #000" colspan="3">
+                <b>Z-Probe</b>
+              </td>
+            </tr>
+            <tr>
+              <td><b>SKU</b></td>
+              <td><b>Name</b></td>
+              <td><b>Quantity</b></td>
+            </tr>
+            <tr>
+              <td>30611-02</td>
+              <td>Z-Probe Kit</td>
+              <td>1</td>
+            </tr>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
 </div>

--- a/1000mm/index.md
+++ b/1000mm/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: 'Welcome!'
 step_number: 1
 permalink: /1000mm/
-next-step: /1000mm/step1/
-next-step-title: 'Work Area'
+next_step: /1000mm/step1/
+next_step_title: 'Work Area'
 ---
 
 <img src="../x-carve-main.jpg">

--- a/1000mm/step1/index.md
+++ b/1000mm/step1/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: "Work Area"
 step_number: 1
 permalink: /1000mm/step1/
-next-step: /1000mm/step2a/1sideplates/
-next-step-title: "Gantry"
+next_step: /1000mm/step2a/1sideplates/
+next_step_title: "Gantry"
 ---
 
 <table>

--- a/1000mm/step1/index.md
+++ b/1000mm/step1/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Work Area"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step1/
 next-step: /1000mm/step2a/1sideplates/
 next-step-title: "Gantry"

--- a/1000mm/step10/index.md
+++ b/1000mm/step10/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Computer Setup"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step10/
 ---
 

--- a/1000mm/step2a/1sideplates/index.md
+++ b/1000mm/step2a/1sideplates/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Gantry Side Plates"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/1sideplates/
 next-step: /1000mm/step2a/2fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/1000mm/step2a/1sideplates/index.md
+++ b/1000mm/step2a/1sideplates/index.md
@@ -4,8 +4,8 @@ title: "Gantry Side Plates"
 parent: "Side Plates"
 step_number: 2
 permalink: /1000mm/step2a/1sideplates/
-next-step: /1000mm/step2a/2fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /1000mm/step2a/2fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 ---
 
 <img src="../../step2/photo/jpfs_DSC2610.jpg">

--- a/1000mm/step2a/2fixedvwheels/index.md
+++ b/1000mm/step2a/2fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Fixed V-Wheels"
 parent: Side Plates
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/2fixedvwheels/
 next-step: /1000mm/step2a/3adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/1000mm/step2a/2fixedvwheels/index.md
+++ b/1000mm/step2a/2fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: Side Plates
 step_number: 2
 permalink: /1000mm/step2a/2fixedvwheels/
-next-step: /1000mm/step2a/3adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /1000mm/step2a/3adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "fixedvwheels1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2564.jpg">

--- a/1000mm/step2a/3adjustablevwheels/index.md
+++ b/1000mm/step2a/3adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: "Side Plates"
 step_number: 2
 permalink: /1000mm/step2a/3adjustablevwheels/
-next-step: /1000mm/step2a/4idlers/
-next-step-title: "Idler Wheels"
+next_step: /1000mm/step2a/4idlers/
+next_step_title: "Idler Wheels"
 diagram: "adjustablevwheels1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2591.jpg">

--- a/1000mm/step2a/3adjustablevwheels/index.md
+++ b/1000mm/step2a/3adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Adjustable V-Wheels"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/3adjustablevwheels/
 next-step: /1000mm/step2a/4idlers/
 next-step-title: "Idler Wheels"

--- a/1000mm/step2a/4idlers/index.md
+++ b/1000mm/step2a/4idlers/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Idler Wheels"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/4idlers/
 next-step: /1000mm/step2a/5motors/
 next-step-title: "Stepper Motors"

--- a/1000mm/step2a/4idlers/index.md
+++ b/1000mm/step2a/4idlers/index.md
@@ -4,8 +4,8 @@ title: "Attach Idler Wheels"
 parent: "Side Plates"
 step_number: 2
 permalink: /1000mm/step2a/4idlers/
-next-step: /1000mm/step2a/5motors/
-next-step-title: "Stepper Motors"
+next_step: /1000mm/step2a/5motors/
+next_step_title: "Stepper Motors"
 diagram: "idlers1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2597.jpg">

--- a/1000mm/step2a/5motors/index.md
+++ b/1000mm/step2a/5motors/index.md
@@ -4,8 +4,8 @@ title: "Attach Stepper Motors"
 parent: "Side Plates"
 step_number: 2
 permalink: /1000mm/step2a/5motors/
-next-step: /1000mm/step2a/6dragchain/
-next-step-title: "Drag Chain"
+next_step: /1000mm/step2a/6dragchain/
+next_step_title: "Drag Chain"
 diagram: "motors1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2606.jpg">

--- a/1000mm/step2a/5motors/index.md
+++ b/1000mm/step2a/5motors/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Stepper Motors"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/5motors/
 next-step: /1000mm/step2a/6dragchain/
 next-step-title: "Drag Chain"

--- a/1000mm/step2a/6dragchain/index.md
+++ b/1000mm/step2a/6dragchain/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Bracket"
 parent: "Side Plates"
 step_number: 2
 permalink: /1000mm/step2a/6dragchain/
-next-step: /1000mm/step2a/7homeswitch/
-next-step-title: "Homing Switches"
+next_step: /1000mm/step2a/7homeswitch/
+next_step_title: "Homing Switches"
 diagram: "dragchain1.jpg"
 ---
 <img src="jpfsimage4.jpg">

--- a/1000mm/step2a/6dragchain/index.md
+++ b/1000mm/step2a/6dragchain/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Drag Chain Bracket"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/6dragchain/
 next-step: /1000mm/step2a/7homeswitch/
 next-step-title: "Homing Switches"

--- a/1000mm/step2a/7homeswitch/index.md
+++ b/1000mm/step2a/7homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Homing Switches"
 parent: "Side Plates"
 step_number: 2
 permalink: /1000mm/step2a/7homeswitch/
-next-step: /1000mm/step2b/1xcarriage/
-next-step-title: "X-Carriage"
+next_step: /1000mm/step2b/1xcarriage/
+next_step_title: "X-Carriage"
 diagram: "homeswitch1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2616.jpg">

--- a/1000mm/step2a/7homeswitch/index.md
+++ b/1000mm/step2a/7homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Homing Switches"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2a/7homeswitch/
 next-step: /1000mm/step2b/1xcarriage/
 next-step-title: "X-Carriage"

--- a/1000mm/step2b/1xcarriage/index.md
+++ b/1000mm/step2b/1xcarriage/index.md
@@ -4,8 +4,8 @@ title: "Assemble X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/1xcarriage/
-next-step: /1000mm/step2b/2idlers/
-next-step-title: "Idler Wheels"
+next_step: /1000mm/step2b/2idlers/
+next_step_title: "Idler Wheels"
 ---
 
 In this section we'll be assembling The X-Carriage. This carriage carries the hardware for moving the X axis as well as the Z axis, though we'll be assembling the latter component in the next section

--- a/1000mm/step2b/1xcarriage/index.md
+++ b/1000mm/step2b/1xcarriage/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Assemble X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/1xcarriage/
 next-step: /1000mm/step2b/2idlers/
 next-step-title: "Idler Wheels"

--- a/1000mm/step2b/2idlers/index.md
+++ b/1000mm/step2b/2idlers/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Smooth Idlers"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/2idlers/
 next-step: /1000mm/step2b/3fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/1000mm/step2b/2idlers/index.md
+++ b/1000mm/step2b/2idlers/index.md
@@ -4,8 +4,8 @@ title: "Attach Smooth Idlers"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/2idlers/
-next-step: /1000mm/step2b/3fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /1000mm/step2b/3fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 diagram: "idlers.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150151.jpg">

--- a/1000mm/step2b/3fixedvwheels/index.md
+++ b/1000mm/step2b/3fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Fixed V-Wheels"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/3fixedvwheels/
 next-step: /1000mm/step2b/4adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/1000mm/step2b/3fixedvwheels/index.md
+++ b/1000mm/step2b/3fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/3fixedvwheels/
-next-step: /1000mm/step2b/4adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /1000mm/step2b/4adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "fixedvwheels.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2641.jpg">

--- a/1000mm/step2b/4adjustablevwheels/index.md
+++ b/1000mm/step2b/4adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/4adjustablevwheels/
-next-step: /1000mm/step2b/5motors/
-next-step-title: "Stepper Motors"
+next_step: /1000mm/step2b/5motors/
+next_step_title: "Stepper Motors"
 diagram: "adjustablevwheels.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2648.jpg">

--- a/1000mm/step2b/4adjustablevwheels/index.md
+++ b/1000mm/step2b/4adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Adjustable V-Wheels"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/4adjustablevwheels/
 next-step: /1000mm/step2b/5motors/
 next-step-title: "Stepper Motors"

--- a/1000mm/step2b/5motors/index.md
+++ b/1000mm/step2b/5motors/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Stepper Motor to X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/5motors/
 next-step: /1000mm/step2b/6dragchain/
 next-step-title: "Drag Chain Bracket"

--- a/1000mm/step2b/5motors/index.md
+++ b/1000mm/step2b/5motors/index.md
@@ -4,8 +4,8 @@ title: "Attach Stepper Motor to X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/5motors/
-next-step: /1000mm/step2b/6dragchain/
-next-step-title: "Drag Chain Bracket"
+next_step: /1000mm/step2b/6dragchain/
+next_step_title: "Drag Chain Bracket"
 diagram: "motors.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2652.jpg">

--- a/1000mm/step2b/6dragchain/index.md
+++ b/1000mm/step2b/6dragchain/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Drag Chain Bracket To X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/6dragchain/
 next-step: /1000mm/step2b/7homeswitch/
 next-step-title: "Homing Switch"

--- a/1000mm/step2b/6dragchain/index.md
+++ b/1000mm/step2b/6dragchain/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Bracket To X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/6dragchain/
-next-step: /1000mm/step2b/7homeswitch/
-next-step-title: "Homing Switch"
+next_step: /1000mm/step2b/7homeswitch/
+next_step_title: "Homing Switch"
 diagram: "dragchain.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150160.jpg">

--- a/1000mm/step2b/7homeswitch/index.md
+++ b/1000mm/step2b/7homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Home Switch to X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2b/7homeswitch/
 next-step: /1000mm/step2c/1zaxis/
 next-step-title: "Z-Axis"

--- a/1000mm/step2b/7homeswitch/index.md
+++ b/1000mm/step2b/7homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Home Switch to X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /1000mm/step2b/7homeswitch/
-next-step: /1000mm/step2c/1zaxis/
-next-step-title: "Z-Axis"
+next_step: /1000mm/step2c/1zaxis/
+next_step_title: "Z-Axis"
 diagram: "homeswitch.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150166.jpg">

--- a/1000mm/step2c/01zaxis/index.md
+++ b/1000mm/step2c/01zaxis/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Z-Axis"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/1zaxis/
 next-step: /1000mm/step2c/2flangedbearing/
 next-step-title: "Flanged Bearing"

--- a/1000mm/step2c/01zaxis/index.md
+++ b/1000mm/step2c/01zaxis/index.md
@@ -4,8 +4,8 @@ title: "Z-Axis"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/1zaxis/
-next-step: /1000mm/step2c/2flangedbearing/
-next-step-title: "Flanged Bearing"
+next_step: /1000mm/step2c/2flangedbearing/
+next_step_title: "Flanged Bearing"
 ---
 
 In this section we'll assemble the Z-Axis rail, leadscrew, and spindle mount. This assembly will be attached to the X-Carriage.

--- a/1000mm/step2c/02flangedbearing/index.md
+++ b/1000mm/step2c/02flangedbearing/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Flanged Bearing to Z-Axis Plate"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/2flangedbearing/
 next-step: /1000mm/step2c/3attachrail/
 next-step-title: "Z-Axis Rail"

--- a/1000mm/step2c/02flangedbearing/index.md
+++ b/1000mm/step2c/02flangedbearing/index.md
@@ -4,8 +4,8 @@ title: "Attach Flanged Bearing to Z-Axis Plate"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/2flangedbearing/
-next-step: /1000mm/step2c/3attachrail/
-next-step-title: "Z-Axis Rail"
+next_step: /1000mm/step2c/3attachrail/
+next_step_title: "Z-Axis Rail"
 diagram: "../02flangedbearing/flangedbearing.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2684.jpg">

--- a/1000mm/step2c/03attachrail/index.md
+++ b/1000mm/step2c/03attachrail/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Rail"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/3attachrail/
-next-step: /1000mm/step2c/4leadscrew/
-next-step-title: "Leadscrew"
+next_step: /1000mm/step2c/4leadscrew/
+next_step_title: "Leadscrew"
 diagram: "../03attachrail/attachrail.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2687.jpg">

--- a/1000mm/step2c/03attachrail/index.md
+++ b/1000mm/step2c/03attachrail/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Z-Axis Rail"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/3attachrail/
 next-step: /1000mm/step2c/4leadscrew/
 next-step-title: "Leadscrew"

--- a/1000mm/step2c/04leadscrew/index.md
+++ b/1000mm/step2c/04leadscrew/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Install Leadscrew"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/4leadscrew/
 next-step: /1000mm/step2c/5attachtocarriage/
 next-step-title: "Attach Z-Axis"

--- a/1000mm/step2c/04leadscrew/index.md
+++ b/1000mm/step2c/04leadscrew/index.md
@@ -4,8 +4,8 @@ title: "Install Leadscrew"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/4leadscrew/
-next-step: /1000mm/step2c/5attachtocarriage/
-next-step-title: "Attach Z-Axis"
+next_step: /1000mm/step2c/5attachtocarriage/
+next_step_title: "Attach Z-Axis"
 diagram: "../04leadscrew/leadscrew.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2705.jpg">

--- a/1000mm/step2c/05attachtocarriage/index.md
+++ b/1000mm/step2c/05attachtocarriage/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Assembly to X-Carriage"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/5attachtocarriage/
-next-step: /1000mm/step2c/6adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /1000mm/step2c/6adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "../05attachtocarriage/attachtocarriage1.jpg"
 ---
 <img src="../../../photo/jpfsPA120456.jpg">

--- a/1000mm/step2c/05attachtocarriage/index.md
+++ b/1000mm/step2c/05attachtocarriage/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Z-Axis Assembly to X-Carriage"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/5attachtocarriage/
 next-step: /1000mm/step2c/6adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/1000mm/step2c/06adjustablevwheels/index.md
+++ b/1000mm/step2c/06adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Adjustable V-Wheels"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/6adjustablevwheels/
 next-step: /1000mm/step2c/7fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/1000mm/step2c/06adjustablevwheels/index.md
+++ b/1000mm/step2c/06adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/6adjustablevwheels/
-next-step: /1000mm/step2c/7fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /1000mm/step2c/7fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 diagram: "../06adjustablevwheels/adjustablevwheels3.jpg"
 ---
 

--- a/1000mm/step2c/07fixedvwheels/index.md
+++ b/1000mm/step2c/07fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Fixed V-Wheels"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/7fixedvwheels/
 next-step: /1000mm/step2c/8clampbolts/
 next-step-title: "Clamp Bolts"

--- a/1000mm/step2c/07fixedvwheels/index.md
+++ b/1000mm/step2c/07fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/7fixedvwheels/
-next-step: /1000mm/step2c/8clampbolts/
-next-step-title: "Clamp Bolts"
+next_step: /1000mm/step2c/8clampbolts/
+next_step_title: "Clamp Bolts"
 diagram: "../07fixedvwheels/fixedvwheels3.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2749.jpg">

--- a/1000mm/step2c/08clampbolts/index.md
+++ b/1000mm/step2c/08clampbolts/index.md
@@ -4,8 +4,8 @@ title: "Insert Spindle Carriage Clamping Bolts"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/8clampbolts/
-next-step: /1000mm/step2c/9attachmount/
-next-step-title: "Attach Spindle Mount"
+next_step: /1000mm/step2c/9attachmount/
+next_step_title: "Attach Spindle Mount"
 diagram: "../08clampbolts/clampbolts.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2750.jpg">

--- a/1000mm/step2c/08clampbolts/index.md
+++ b/1000mm/step2c/08clampbolts/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Insert Spindle Carriage Clamping Bolts"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/8clampbolts/
 next-step: /1000mm/step2c/9attachmount/
 next-step-title: "Attach Spindle Mount"

--- a/1000mm/step2c/09attachmount/index.md
+++ b/1000mm/step2c/09attachmount/index.md
@@ -4,8 +4,8 @@ title: "Attach Spindle Carriage to Z-Axis"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/9attachmount/
-next-step: /1000mm/step2c/10homeswitch/
-next-step-title: "Z-Axis Homing Switch"
+next_step: /1000mm/step2c/10homeswitch/
+next_step_title: "Z-Axis Homing Switch"
 diagram: "../09attachmount/attachmount1.jpg"
 diagram2: "../09attachmount/attachmount2.jpg"
 ---

--- a/1000mm/step2c/09attachmount/index.md
+++ b/1000mm/step2c/09attachmount/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Spindle Carriage to Z-Axis"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/9attachmount/
 next-step: /1000mm/step2c/10homeswitch/
 next-step-title: "Z-Axis Homing Switch"

--- a/1000mm/step2c/10homeswitch/index.md
+++ b/1000mm/step2c/10homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Z-Axis Home Switch"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2c/10homeswitch/
 next-step: /1000mm/step2d/1gantryrail/
 next-step-title: "Assemble Gantry"

--- a/1000mm/step2c/10homeswitch/index.md
+++ b/1000mm/step2c/10homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Home Switch"
 parent: Z-Axis
 step_number: 2
 permalink: /1000mm/step2c/10homeswitch/
-next-step: /1000mm/step2d/1gantryrail/
-next-step-title: "Assemble Gantry"
+next_step: /1000mm/step2d/1gantryrail/
+next_step_title: "Assemble Gantry"
 ---
 
 <table>

--- a/1000mm/step2d/1gantryrail/index.md
+++ b/1000mm/step2d/1gantryrail/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Gantry"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2d/1gantryrail/
 next-step: /1000mm/step2d/2attachsideplate/
 next-step-title: "Attach First Plate"

--- a/1000mm/step2d/1gantryrail/index.md
+++ b/1000mm/step2d/1gantryrail/index.md
@@ -4,8 +4,8 @@ title: "Gantry"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /1000mm/step2d/1gantryrail/
-next-step: /1000mm/step2d/2attachsideplate/
-next-step-title: "Attach First Plate"
+next_step: /1000mm/step2d/2attachsideplate/
+next_step_title: "Attach First Plate"
 ---
 We will now assemble the main gantry of the machine using the sub-assemblies you've built thus far. After this is assembled, your machine's frame will almost be complete.
 

--- a/1000mm/step2d/2attachsideplate/index.md
+++ b/1000mm/step2d/2attachsideplate/index.md
@@ -4,8 +4,8 @@ title: "Attach Side Plate"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /1000mm/step2d/2attachsideplate/
-next-step: /1000mm/step2d/3attachcarriage/
-next-step-title: "Attach Carriage"
+next_step: /1000mm/step2d/3attachcarriage/
+next_step_title: "Attach Carriage"
 ---
 
 <table>

--- a/1000mm/step2d/2attachsideplate/index.md
+++ b/1000mm/step2d/2attachsideplate/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Side Plate"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2d/2attachsideplate/
 next-step: /1000mm/step2d/3attachcarriage/
 next-step-title: "Attach Carriage"

--- a/1000mm/step2d/3attachcarriage/index.md
+++ b/1000mm/step2d/3attachcarriage/index.md
@@ -4,8 +4,8 @@ title: "Attach X-Carriage Assembly"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /1000mm/step2d/3attachcarriage/
-next-step: /1000mm/step2d/4attachsideplate/
-next-step-title: "Side Plate"
+next_step: /1000mm/step2d/4attachsideplate/
+next_step_title: "Side Plate"
 ---
 
 

--- a/1000mm/step2d/3attachcarriage/index.md
+++ b/1000mm/step2d/3attachcarriage/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach X-Carriage Assembly"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2d/3attachcarriage/
 next-step: /1000mm/step2d/4attachsideplate/
 next-step-title: "Side Plate"

--- a/1000mm/step2d/4attachsideplate/index.md
+++ b/1000mm/step2d/4attachsideplate/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Gantry"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2d/4attachsideplate/
 next-step: /1000mm/step2d/5dragchainrail/
 next-step-title: "Drag Chain Rail"

--- a/1000mm/step2d/4attachsideplate/index.md
+++ b/1000mm/step2d/4attachsideplate/index.md
@@ -4,8 +4,8 @@ title: "Gantry"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /1000mm/step2d/4attachsideplate/
-next-step: /1000mm/step2d/5dragchainrail/
-next-step-title: "Drag Chain Rail"
+next_step: /1000mm/step2d/5dragchainrail/
+next_step_title: "Drag Chain Rail"
 ---
 
 <table>

--- a/1000mm/step2d/5dragchainrail/index.md
+++ b/1000mm/step2d/5dragchainrail/index.md
@@ -2,7 +2,7 @@
 layout: default1000mm
 title: "Attach Drag Chain Rail"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /1000mm/step2d/5dragchainrail/
 next-step: /1000mm/step3/
 next-step-title: "Rails"

--- a/1000mm/step2d/5dragchainrail/index.md
+++ b/1000mm/step2d/5dragchainrail/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Rail"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /1000mm/step2d/5dragchainrail/
-next-step: /1000mm/step3/
-next-step-title: "Rails"
+next_step: /1000mm/step3/
+next_step_title: "Rails"
 ---
 
 <table>

--- a/1000mm/step3/index.md
+++ b/1000mm/step3/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Rails"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step3/
 next-step: /1000mm/step4/
 next-step-title: "Belting"

--- a/1000mm/step3/index.md
+++ b/1000mm/step3/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: "Rails"
 step_number: 1
 permalink: /1000mm/step3/
-next-step: /1000mm/step4/
-next-step-title: "Belting"
+next_step: /1000mm/step4/
+next_step_title: "Belting"
 ---
 In this step, you'll be assembling the main y axis rails and attaching them to the gantry. You'll then attach this assembly to the work area.
 

--- a/1000mm/step4/index.md
+++ b/1000mm/step4/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Belting"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step4/
 next-step: /1000mm/step5/
 next-step-title: "Spindle"

--- a/1000mm/step4/index.md
+++ b/1000mm/step4/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: "Belting"
 step_number: 1
 permalink: /1000mm/step4/
-next-step: /1000mm/step5/
-next-step-title: "Spindle"
+next_step: /1000mm/step5/
+next_step_title: "Spindle"
 ---
 <p>This section covers installing the belting.</p>
 

--- a/1000mm/step5/index.md
+++ b/1000mm/step5/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Spindle"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step5/
 next-step: /1000mm/step6/
 next-step-title: "Wiring"

--- a/1000mm/step5/index.md
+++ b/1000mm/step5/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: "Spindle"
 step_number: 1
 permalink: /1000mm/step5/
-next-step: /1000mm/step6/
-next-step-title: "Wiring"
+next_step: /1000mm/step6/
+next_step_title: "Wiring"
 ---
 In this step you'll be mounting a DeWalt 611 router in the spindle mount. Begin by removing existing base and collar from the spindle. This will leave just the metal router body.
 <img src="./photo/jpfs_DSC2846.jpg">

--- a/1000mm/step6/index.md
+++ b/1000mm/step6/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Wiring"
-step-number: 6
+step_number: 6
 permalink: /1000mm/step6/
 next-step: /1000mm/step7/
 next-step-title: "Side Board"

--- a/1000mm/step6/index.md
+++ b/1000mm/step6/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: "Wiring"
 step_number: 6
 permalink: /1000mm/step6/
-next-step: /1000mm/step7/
-next-step-title: "Side Board"
+next_step: /1000mm/step7/
+next_step_title: "Side Board"
 diagram: "wiringDiagram750placeholder.jpg"
 ---
 <table>

--- a/1000mm/step7/index.md
+++ b/1000mm/step7/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title: "Side Board"
 step_number: 1
 permalink: /1000mm/step7/
-next-step: /1000mm/step8/
-next-step-title: "X-Controller"
+next_step: /1000mm/step8/
+next_step_title: "X-Controller"
 ---
 <table>
   <tr>

--- a/1000mm/step7/index.md
+++ b/1000mm/step7/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title: "Side Board"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step7/
 next-step: /1000mm/step8/
 next-step-title: "X-Controller"

--- a/1000mm/step8/index.md
+++ b/1000mm/step8/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title:  "X-Controller"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step8/
 next-step: /1000mm/step9/
 next-step-title: "Calibrate"

--- a/1000mm/step8/index.md
+++ b/1000mm/step8/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title:  "X-Controller"
 step_number: 1
 permalink: /1000mm/step8/
-next-step: /1000mm/step9/
-next-step-title: "Calibrate"
+next_step: /1000mm/step9/
+next_step_title: "Calibrate"
 ---
 
 <img src="PB231421BATCH201.jpg">

--- a/1000mm/step9/index.md
+++ b/1000mm/step9/index.md
@@ -3,8 +3,8 @@ layout: default1000mm
 title:  "Calibrate"
 step_number: 1
 permalink: /1000mm/step9/
-next-step: /1000mm/step10/
-next-step-title: "Computer Setup"
+next_step: /1000mm/step10/
+next_step_title: "Computer Setup"
 ---
 
 *Note:* Many of the mechanical problems you'll face in the future can be fixed using the following information.

--- a/1000mm/step9/index.md
+++ b/1000mm/step9/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default1000mm
 title:  "Calibrate"
-step-number: 1
+step_number: 1
 permalink: /1000mm/step9/
 next-step: /1000mm/step10/
 next-step-title: "Computer Setup"

--- a/500mm/index.md
+++ b/500mm/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: 'Welcome!'
 step_number: 1
 permalink: /500mm/
-next-step: /500mm/step1/
-next-step-title: 'Work Area'
+next_step: /500mm/step1/
+next_step_title: 'Work Area'
 ---
 
 <img src="500_angle_0101.jpg">

--- a/500mm/index.md
+++ b/500mm/index.md
@@ -1,23 +1,23 @@
 ---
 layout: default500mm
-title: "Welcome!"
+title: 'Welcome!'
 step-number: 1
 permalink: /500mm/
 next-step: /500mm/step1/
-next-step-title: "Work Area"
+next-step-title: 'Work Area'
 ---
 
 <img src="500_angle_0101.jpg">
 
-Congratulations!  You've just taken one of your first steps into the world of 3D Carving!  This guide will take you through the steps of building your very own X-Carve 3D Carver! We've tried to make it as easy as possible to get you from unpacking your parts to carving.  We've laid out the instructions starting from the bottom of the machine to the top, and we will cover everything from machine assembly to computer setup.
+Congratulations! You've just taken one of your first steps into the world of 3D Carving! This guide will take you through the steps of building your very own X-Carve 3D Carver! We've tried to make it as easy as possible to get you from unpacking your parts to carving. We've laid out the instructions starting from the bottom of the machine to the top, and we will cover everything from machine assembly to computer setup.
 
-This is a do-it-yourself 3D carving kit: the more time and attention you put into assembling your machine, the better it will perform.  If you run into any trouble during assembly or carving you can find further help from the wonderful community on the forum, our support center which is continuously growing with articles and tutorials, and as always you can reach our customer success team through our [support center](https://inventables.desk.com/) or by phone at 312 775 7009.
+This is a do-it-yourself 3D carving kit: the more time and attention you put into assembling your machine, the better it will perform. If you run into any trouble during assembly or carving you can find further help from the wonderful community on the forum, our support center which is continuously growing with articles and tutorials, and as always you can reach our customer success team through our [support center](https://inventables.desk.com/) or by phone at 312 775 7009.
 
 The X-Carve is open source hardware. We have 3D models and drawings available in a GrabCAD repository <a href="https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcojYwyy_VqboQQ-9hKBJrjS3zGaGuue8sfnqRNxGI9WQS">here</a>.
 
 <h2>Recommended Tools</h2>
 
-If you purchased a tool kit with your machine, most of these should be included with the exception of power tools 
+If you purchased a tool kit with your machine, most of these should be included with the exception of power tools
 
 - 7mm wrench or socket
 - 8mm wrench or socket
@@ -33,1669 +33,886 @@ If you purchased a tool kit with your machine, most of these should be included 
 
 <h2>Bill of Materials</h2>
 <div class="bom">
-<div class="panel-group" id="core-components-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#core-components-accordion" href="#core-components" aria-expanded="false" aria-controls="core-components" style="color:#fff;background:#383838" class="panel-heading" role="tab" id="core-components-header">
-<h4 class="panel-title">
-<strong>Core Components</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="core-components" class="panel-collapse collapse" role="tabpanel" aria-labelledby="core-components-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #383838" colspan="3">
-      <b>Core Components Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30524-01
-    </td>
-    <td>
-      MakerSlide End Plate
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30525-01
-    </td>
-    <td>
-      Gantry Side Plate
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30526-01
-    </td>
-    <td>
-      Belt Clip
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30677-01
-    </td>
-    <td>
-      Belt Sleeve Clip
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30396-02
-    </td>
-    <td>
-      ACME Lead Screw
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25195-07
-    </td>
-    <td>
-      Eccentric Spacer 0.200" Long
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25195-08
-    </td>
-    <td>
-      Eccentric Spacer 0.375" Long
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30534-01
-    </td>
-    <td>
-      Z Axis Motor Plate
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-12
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      18
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26054-04
-    </td>
-    <td>
-      Aluminum GT2 Pulley 20T 8mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25280-03
-    </td>
-    <td>
-      Delrin Nut ACME 3/8-12
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30547-01
-    </td>
-    <td>
-      GT2 Belt Closed Loop, 80T
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25312-23
-    </td>
-    <td>
-      Aluminum Spacer 5.1mm ID 9.5mm OD 9.5mm LG
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-11
-    </td>
-    <td>
-      Flat Washer M8
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30545-01
-    </td>
-    <td>
-      X Carriage Extrusion
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25142-09
-    </td>
-    <td>
-      MakerSlide 200mm Tapped Black
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25203-01
-    </td>
-    <td>
-      V Wheel Assembly
-    </td>
-    <td>
-      20
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25197-01
-    </td>
-    <td>
-      Smooth Idler Pulley Assembly
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-33
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 8
-    </td>
-    <td>
-      16
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-35
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-38
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      16
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-46
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-43
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 25
-    </td>
-    <td>
-      11
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-49
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 30
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-48
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 40
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30169-01
-    </td>
-    <td>
-      Flanged Bearing, 8mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30552-05
-    </td>
-    <td>
-      Flat Head Screw M5 x 35
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-12
-    </td>
-    <td>
-      M5 Flat Washer
-    </td>
-    <td>
-      26
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-09
-    </td>
-    <td>
-      Nylon Insert Lock Nut M5
-    </td>
-    <td>
-      41
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-05
-    </td>
-    <td>
-      Nylon Insert Lock Nut M6
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-54
-    </td>
-    <td>
-      Socket Head Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-52
-    </td>
-    <td>
-      Socket Head Screw M5 x 16
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-53
-    </td>
-    <td>
-      Socket Head Screw M5 x 20
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30711-01
-    </td>
-    <td>
-      Lubricant
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
-<h4 class="panel-title">
-<strong>Rail Size</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="rail-size" class="panel-collapse collapse" role="tabpanel" aria-labelledby="rail-size-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#000;background: #FFFFFF" colspan="3">
-      <b>500mm Rail Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-02
-    </td>
-    <td>
-      X-Carve Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26053-01
-    </td>
-    <td>
-      GT2 Belting - Open Ended (feet)
-    </td>
-    <td>
-      7
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-01
-    </td>
-    <td>
-      Aluminum Extrusion 20 × 20 × 500mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30678-01
-    </td>
-    <td>
-      MakerSlide Extra Wide 500mm Tapped Black
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25142-10
-    </td>
-    <td>
-      MakerSlide Black 500mm Lg
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-14
-    </td>
-    <td>
-      M5 pre-assembly insertion nut
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26018-01
-    </td>
-    <td>
-      Extrusion Bracket (Gusset)
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-11
-    </td>
-    <td>
-      Aluminum Extrusion 20mm × 20mm Black 458mm Lg
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-35
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="motors-and-wiring-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#motors-and-wiring-accordion" href="#motors-and-wiring" aria-expanded="false" aria-controls="motors-and-wiring" style="color:#fff;background:#CC3440" class="panel-heading" role="tab" id="motors-and-wiring-header">
-<h4 class="panel-title">
-<strong>Motors and Wiring</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="motors-and-wiring" class="panel-collapse collapse" role="tabpanel" aria-labelledby="motors-and-wiring-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #CC3440" colspan="3">
-      <b>500mm Motor and Wiring Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25311-06
-    </td>
-    <td>
-      Stepper Motor - NEMA 23
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-01
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 58 in long (X-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-02
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 29 in long (Y1-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-03
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 53 in long (Y2-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-04
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 58 in long (Z-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="drag-chain-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#drag-chain-accordion" href="#drag-chain" aria-expanded="false" aria-controls="drag-chain" style="color:#fff;background:#8A52A1" class="panel-heading" role="tab" id="drag-chain-header">
-<h4 class="panel-title">
-<strong>Drag Chain</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="drag-chain" class="panel-collapse collapse" role="tabpanel" aria-labelledby="drag-chain-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #8A52A1" colspan="3">
-      <b>500mm Drag Chain Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30527-05
-    </td>
-    <td>
-      Drag Chain Bracket
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30527-06
-    </td>
-    <td>
-      Drag Chain Bracket
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30680-01
-    </td>
-    <td>
-      Zip Tie Mount
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26016-03
-    </td>
-    <td>
-      T-Nut M5 Post Assembly
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30681-01
-    </td>
-    <td>
-      Drag Chain Support Arm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30331-11
-    </td>
-    <td>
-      Drag Chain 18x25 12 Links w/ Custom Ends
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25986-03
-    </td>
-    <td>
-      Cable Tie 4" (100 Pack)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-07
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 500mm Tapped
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-44
-    </td>
-    <td>
-      Button Head Cap Screw M4 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-31
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 6
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-46
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30554-06
-    </td>
-    <td>
-      Flat Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30554-07
-    </td>
-    <td>
-      Flat Head Cap Screw M5 x 12
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-08
-    </td>
-    <td>
-      Hex Nut M4 Nylon Locking
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-10
-    </td>
-    <td>
-      Hex Nut M5 Nylon Locking
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="home-switch-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#home-switch-accordion" href="#home-switch" aria-expanded="false" aria-controls="home-switch" style="color:#fff;background:#F47B44" class="panel-heading" role="tab" id="home-switch-header">
-<h4 class="panel-title">
-<strong>Home Switch</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="home-switch" class="panel-collapse collapse" role="tabpanel" aria-labelledby="home-switch-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #F47B44" colspan="3">
-      <b>500mm Homing Switch Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30557-02
-    </td>
-    <td>
-      Microswitch
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26016-03
-    </td>
-    <td>
-      T-Nut M5 Post Assembly
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-01
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 60"Lg X-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-02
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 37"Lg Y-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-03
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 60"Lg Z-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25312-25
-    </td>
-    <td>
-      Spacer 5.1mm ID 9.5mm 10.5mm Lg Aluminum
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25284-12
-    </td>
-    <td>
-      Hex Nut M2x0.4
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-07
-    </td>
-    <td>
-      Hex Nut M3 Nylon Locking
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-56
-    </td>
-    <td>
-      Socket Head Screw M2 x 10 
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-57
-    </td>
-    <td>
-      Socket Head Screw M2 x 14 
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-44
-    </td>
-    <td>
-      Socket Head Screw M3 x 20
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-51
-    </td>
-    <td>
-      Socket Head Screw M5 x 16
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30555-03
-    </td>
-    <td>
-      Washer, Split Lock M2 Stainless
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="waste-board-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#waste-board-accordion" href="#waste-board" aria-expanded="false" aria-controls="waste-board" style="color:#fff;background:#0a91d1" class="panel-heading" role="tab" id="waste-board-header">
-<h4 class="panel-title">
-<strong>Waste Board</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="waste-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="waste-board-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #0a91d1" colspan="3">
-      <b>500mm Waste Board Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-09
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30517-07
-    </td>
-    <td>
-      Threaded Insert M5 x 10
-    </td>
-    <td>
-      25
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30535-02
-    </td>
-    <td>
-      500mm Waste Board
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-39
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="side-board-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#side-board-accordion" href="#side-board" aria-expanded="false" aria-controls="side-board" style="color:#fff;background:#9D9FA2" class="panel-heading" role="tab" id="side-board-header">
-<h4 class="panel-title">
-<strong>Side Board</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="side-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="side-board-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #9D9FA2" colspan="3">
-      <b>500mm Side Board Assembly</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30684-01
-    </td>
-    <td>
-      Extrusion Connection Bracket
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-13
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      21
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26018-01
-    </td>
-    <td>
-      Cast Corner Bracket, Clear
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30517-10
-    </td>
-    <td>
-      Threaded Insert M5
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30685-01
-    </td>
-    <td>
-      Side Board, X-Carve 500mm Size
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-10
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 250mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-11
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 458mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-34
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 8
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-37
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-41
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-50
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="spindle-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#spindle-accordion" href="#spindle" aria-expanded="false" aria-controls="spindle" style="color:#fff;background:#42a44e" class="panel-heading" role="tab" id="spindle-header">
-<h4 class="panel-title">
-<strong>Spindle</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="spindle" class="panel-collapse collapse" role="tabpanel" aria-labelledby="spindle-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>110V DeWalt 611 Spindle and Mount</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30621-01
-    </td>
-    <td>
-      DeWalt 611 Router
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>240V DeWalt 611 Spindle and Mount</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30621-02
-    </td>
-    <td>
-      240V DeWalt 26200 router
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>X-Carve DeWalt 611 Spindle Mount (Does Not Include Spindle)</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>Bosch Colt Spindle Mount Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30287-01
-    </td>
-    <td>
-      Spindle Mounting Plate
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30329-03
-    </td>
-    <td>
-      Bosch Colt Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30549-01
-    </td>
-    <td>
-      Rubber Inventables Sticker
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-18
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-08
-    </td>
-    <td>
-      Flat Washer M5
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-37
-    </td>
-    <td>
-      Socket Head Screw M5 x 20
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-38
-    </td>
-    <td>
-      Socket Head Screw M5 x 25
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30555-01
-    </td>
-    <td>
-      Split Lockwashers M5
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="z-probe-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#z-probe-accordion" href="#z-probe" aria-expanded="false" aria-controls="z-probe" style="color:#fff;background:#000" class="panel-heading" role="tab" id="z-probe-header">
-<h4 class="panel-title">
-<strong>Z-Probe</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="z-probe" class="panel-collapse collapse" role="tabpanel" aria-labelledby="z-probe-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #000" colspan="3">
-      <b>Z-Probe</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30611-02
-    </td>
-    <td>
-      Z-Probe Kit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
+   <div class="panel-group" id="core-components-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#core-components-accordion" href="#core-components" aria-expanded="false" aria-controls="core-components" style="color:#fff;background:#383838" class="panel-heading" role="tab" id="core-components-header">
+            <h4 class="panel-title">
+               <strong>Core Components</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="core-components" class="panel-collapse collapse" role="tabpanel" aria-labelledby="core-components-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #383838" colspan="3">
+                        <b>Core Components Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30524-01</td>
+                     <td>MakerSlide End Plate</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30525-01</td>
+                     <td>Gantry Side Plate</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30526-01</td>
+                     <td>Belt Clip</td>
+                     <td>6</td>
+                  </tr>
+                  <tr>
+                     <td>30677-01</td>
+                     <td>Belt Sleeve Clip</td>
+                     <td>6</td>
+                  </tr>
+                  <tr>
+                     <td>30396-02</td>
+                     <td>ACME Lead Screw</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25195-07</td>
+                     <td>Eccentric Spacer 0.200" Long</td>
+                     <td>8</td>
+                  </tr>
+                  <tr>
+                     <td>25195-08</td>
+                     <td>Eccentric Spacer 0.375" Long</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30534-01</td>
+                     <td>Z Axis Motor Plate</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25281-12</td>
+                     <td>T-Slot Nut M5 Pre-Assembly</td>
+                     <td>18</td>
+                  </tr>
+                  <tr>
+                     <td>26054-04</td>
+                     <td>Aluminum GT2 Pulley 20T 8mm</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25280-03</td>
+                     <td>Delrin Nut ACME 3/8-12</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30547-01</td>
+                     <td>GT2 Belt Closed Loop, 80T</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25312-23</td>
+                     <td>Aluminum Spacer 5.1mm ID 9.5mm OD 9.5mm LG</td>
+                     <td>8</td>
+                  </tr>
+                  <tr>
+                     <td>25287-11</td>
+                     <td>Flat Washer M8</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30545-01</td>
+                     <td>X Carriage Extrusion</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25142-09</td>
+                     <td>MakerSlide 200mm Tapped Black</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25203-01</td>
+                     <td>V Wheel Assembly</td>
+                     <td>20</td>
+                  </tr>
+                  <tr>
+                     <td>25197-01</td>
+                     <td>Smooth Idler Pulley Assembly</td>
+                     <td>6</td>
+                  </tr>
+                  <tr>
+                     <td>25286-33</td>
+                     <td>Button Head Cap Screw M5 x 8</td>
+                     <td>16</td>
+                  </tr>
+                  <tr>
+                     <td>25286-35</td>
+                     <td>Button Head Cap Screw M5 x 10</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>25286-38</td>
+                     <td>Button Head Cap Screw M5 x 12</td>
+                     <td>16</td>
+                  </tr>
+                  <tr>
+                     <td>25286-46</td>
+                     <td>Button Head Cap Screw M5 x 14</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25286-43</td>
+                     <td>Button Head Cap Screw M5 x 25</td>
+                     <td>11</td>
+                  </tr>
+                  <tr>
+                     <td>25286-49</td>
+                     <td>Button Head Cap Screw M5 x 30</td>
+                     <td>12</td>
+                  </tr>
+                  <tr>
+                     <td>25286-48</td>
+                     <td>Button Head Cap Screw M5 x 40</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30169-01</td>
+                     <td>Flanged Bearing, 8mm</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30552-05</td>
+                     <td>Flat Head Screw M5 x 35</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25287-12</td>
+                     <td>M5 Flat Washer</td>
+                     <td>26</td>
+                  </tr>
+                  <tr>
+                     <td>30265-09</td>
+                     <td>Nylon Insert Lock Nut M5</td>
+                     <td>41</td>
+                  </tr>
+                  <tr>
+                     <td>30265-05</td>
+                     <td>Nylon Insert Lock Nut M6</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-54</td>
+                     <td>Socket Head Screw M5 x 10</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>25285-52</td>
+                     <td>Socket Head Screw M5 x 16</td>
+                     <td>8</td>
+                  </tr>
+                  <tr>
+                     <td>25285-53</td>
+                     <td>Socket Head Screw M5 x 20</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30711-01</td>
+                     <td>Lubricant</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
+            <h4 class="panel-title">
+               <strong>Rail Size</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="rail-size" class="panel-collapse collapse" role="tabpanel" aria-labelledby="rail-size-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#000;background: #FFFFFF" colspan="3">
+                        <b>500mm Rail Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30558-02</td>
+                     <td>X-Carve Label</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>26053-01</td>
+                     <td>GT2 Belting - Open Ended (feet)</td>
+                     <td>7</td>
+                  </tr>
+                  <tr>
+                     <td>26049-01</td>
+                     <td>Aluminum Extrusion 20 × 20 × 500mm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30678-01</td>
+                     <td>MakerSlide Extra Wide 500mm Tapped Black</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25142-10</td>
+                     <td>MakerSlide Black 500mm Lg</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25281-14</td>
+                     <td>M5 pre-assembly insertion nut</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>26018-01</td>
+                     <td>Extrusion Bracket (Gusset)</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>26049-11</td>
+                     <td>Aluminum Extrusion 20mm × 20mm Black 458mm Lg</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25286-35</td>
+                     <td>Button Head Cap Screw M5 x 10</td>
+                     <td>4</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="motors-and-wiring-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#motors-and-wiring-accordion" href="#motors-and-wiring" aria-expanded="false" aria-controls="motors-and-wiring" style="color:#fff;background:#CC3440" class="panel-heading" role="tab" id="motors-and-wiring-header">
+            <h4 class="panel-title">
+               <strong>Motors and Wiring</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="motors-and-wiring" class="panel-collapse collapse" role="tabpanel" aria-labelledby="motors-and-wiring-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #CC3440" colspan="3">
+                        <b>500mm Motor and Wiring Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>25311-06</td>
+                     <td>Stepper Motor - NEMA 23</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30679-01</td>
+                     <td>Cable Assembly, Stepper Motor 58 in long (X-Axis)</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30679-02</td>
+                     <td>Cable Assembly, Stepper Motor 29 in long (Y1-Axis)</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30679-03</td>
+                     <td>Cable Assembly, Stepper Motor 53 in long (Y2-Axis)</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30679-04</td>
+                     <td>Cable Assembly, Stepper Motor 58 in long (Z-Axis)</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="drag-chain-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#drag-chain-accordion" href="#drag-chain" aria-expanded="false" aria-controls="drag-chain" style="color:#fff;background:#8A52A1" class="panel-heading" role="tab" id="drag-chain-header">
+            <h4 class="panel-title">
+               <strong>Drag Chain</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="drag-chain" class="panel-collapse collapse" role="tabpanel" aria-labelledby="drag-chain-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #8A52A1" colspan="3">
+                        <b>500mm Drag Chain Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30527-05</td>
+                     <td>Drag Chain Bracket</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30527-06</td>
+                     <td>Drag Chain Bracket</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30680-01</td>
+                     <td>Zip Tie Mount</td>
+                     <td>3</td>
+                  </tr>
+                  <tr>
+                     <td>26016-03</td>
+                     <td>T-Nut M5 Post Assembly</td>
+                     <td>5</td>
+                  </tr>
+                  <tr>
+                     <td>30681-01</td>
+                     <td>Drag Chain Support Arm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30331-11</td>
+                     <td>Drag Chain 18x25 12 Links w/ Custom Ends</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25986-03</td>
+                     <td>Cable Tie 4" (100 Pack)</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>26049-07</td>
+                     <td>Extrusion T-Slot 20x20 x 500mm Tapped</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25286-44</td>
+                     <td>Button Head Cap Screw M4 x 10</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>25286-31</td>
+                     <td>Button Head Cap Screw M5 x 6</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25286-46</td>
+                     <td>Button Head Cap Screw M5 x 14</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30554-06</td>
+                     <td>Flat Head Cap Screw M5 x 10</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30554-07</td>
+                     <td>Flat Head Cap Screw M5 x 12</td>
+                     <td>6</td>
+                  </tr>
+                  <tr>
+                     <td>30265-08</td>
+                     <td>Hex Nut M4 Nylon Locking</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30265-10</td>
+                     <td>Hex Nut M5 Nylon Locking</td>
+                     <td>6</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="home-switch-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#home-switch-accordion" href="#home-switch" aria-expanded="false" aria-controls="home-switch" style="color:#fff;background:#F47B44" class="panel-heading" role="tab" id="home-switch-header">
+            <h4 class="panel-title">
+               <strong>Home Switch</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="home-switch" class="panel-collapse collapse" role="tabpanel" aria-labelledby="home-switch-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #F47B44" colspan="3">
+                        <b>500mm Homing Switch Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30557-02</td>
+                     <td>Microswitch</td>
+                     <td>3</td>
+                  </tr>
+                  <tr>
+                     <td>26016-03</td>
+                     <td>T-Nut M5 Post Assembly</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30682-01</td>
+                     <td>Cable Assembly, 2C Lugs Ferrules 60"Lg X-Limit</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30682-02</td>
+                     <td>Cable Assembly, 2C Lugs Ferrules 37"Lg Y-Limit</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30682-03</td>
+                     <td>Cable Assembly, 2C Lugs Ferrules 60"Lg Z-Limit</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25312-25</td>
+                     <td>Spacer 5.1mm ID 9.5mm 10.5mm Lg Aluminum</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25284-12</td>
+                     <td>Hex Nut M2x0.4</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30265-07</td>
+                     <td>Hex Nut M3 Nylon Locking</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-56</td>
+                     <td>Socket Head Screw M2 x 10 </td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25285-57</td>
+                     <td>Socket Head Screw M2 x 14 </td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>25285-44</td>
+                     <td>Socket Head Screw M3 x 20</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-51</td>
+                     <td>Socket Head Screw M5 x 16</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30555-03</td>
+                     <td>Washer, Split Lock M2 Stainless</td>
+                     <td>6</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="waste-board-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#waste-board-accordion" href="#waste-board" aria-expanded="false" aria-controls="waste-board" style="color:#fff;background:#0a91d1" class="panel-heading" role="tab" id="waste-board-header">
+            <h4 class="panel-title">
+               <strong>Waste Board</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="waste-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="waste-board-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #0a91d1" colspan="3">
+                        <b>500mm Waste Board Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>25281-09</td>
+                     <td>T-Slot Nut M5 Pre-Assembly</td>
+                     <td>6</td>
+                  </tr>
+                  <tr>
+                     <td>30517-07</td>
+                     <td>Threaded Insert M5 x 10</td>
+                     <td>25</td>
+                  </tr>
+                  <tr>
+                     <td>30535-02</td>
+                     <td>500mm Waste Board</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25286-39</td>
+                     <td>Button Head Cap Screw M5 x 12</td>
+                     <td>6</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="side-board-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#side-board-accordion" href="#side-board" aria-expanded="false" aria-controls="side-board" style="color:#fff;background:#9D9FA2" class="panel-heading" role="tab" id="side-board-header">
+            <h4 class="panel-title">
+               <strong>Side Board</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="side-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="side-board-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #9D9FA2" colspan="3">
+                        <b>500mm Side Board Assembly</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30684-01</td>
+                     <td>Extrusion Connection Bracket</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25281-13</td>
+                     <td>T-Slot Nut M5 Pre-Assembly</td>
+                     <td>21</td>
+                  </tr>
+                  <tr>
+                     <td>26018-01</td>
+                     <td>Cast Corner Bracket, Clear</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30517-10</td>
+                     <td>Threaded Insert M5</td>
+                     <td>4</td>
+                  </tr>
+                  <tr>
+                     <td>30685-01</td>
+                     <td>Side Board, X-Carve 500mm Size</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>26049-10</td>
+                     <td>Extrusion T-Slot 20x20 x 250mm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>26049-11</td>
+                     <td>Extrusion T-Slot 20x20 x 458mm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25286-34</td>
+                     <td>Button Head Cap Screw M5 x 8</td>
+                     <td>8</td>
+                  </tr>
+                  <tr>
+                     <td>25286-37</td>
+                     <td>Button Head Cap Screw M5 x 10</td>
+                     <td>8</td>
+                  </tr>
+                  <tr>
+                     <td>25286-41</td>
+                     <td>Button Head Cap Screw M5 x 12</td>
+                     <td>5</td>
+                  </tr>
+                  <tr>
+                     <td>25286-50</td>
+                     <td>Button Head Cap Screw M5 x 14</td>
+                     <td>4</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="spindle-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#spindle-accordion" href="#spindle" aria-expanded="false" aria-controls="spindle" style="color:#fff;background:#42a44e" class="panel-heading" role="tab" id="spindle-header">
+            <h4 class="panel-title">
+               <strong>Spindle</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="spindle" class="panel-collapse collapse" role="tabpanel" aria-labelledby="spindle-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #42a44e" colspan="3">
+                        <b>110V DeWalt 611 Spindle and Mount</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30621-01</td>
+                     <td>DeWalt 611 Router</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30610-01</td>
+                     <td>X-Carve DeWalt 611 Spindle Mount</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-55</td>
+                     <td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+                     <td>3</td>
+                  </tr>
+                  <tr>
+                     <td>25286-45</td>
+                     <td>Button Head Cap Screw M5 × 16mm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30558-01</td>
+                     <td>Inventables Label</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30662-01</td>
+                     <td>1/4" to 1/8" Collet Adapter</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #42a44e" colspan="3">
+                        <b>240V DeWalt 611 Spindle and Mount</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30621-02</td>
+                     <td>240V DeWalt 26200 router</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30610-01</td>
+                     <td>X-Carve DeWalt 611 Spindle Mount</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-55</td>
+                     <td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+                     <td>3</td>
+                  </tr>
+                  <tr>
+                     <td>25286-45</td>
+                     <td>Button Head Cap Screw M5 × 16mm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30558-01</td>
+                     <td>Inventables Label</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30662-01</td>
+                     <td>1/4" to 1/8" Collet Adapter</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #42a44e" colspan="3">
+                        <b>X-Carve DeWalt 611 Spindle Mount (Does Not Include Spindle)</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30610-01</td>
+                     <td>X-Carve DeWalt 611 Spindle Mount</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-55</td>
+                     <td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+                     <td>3</td>
+                  </tr>
+                  <tr>
+                     <td>30558-01</td>
+                     <td>Inventables Label</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25286-45</td>
+                     <td>Button Head Cap Screw M5 × 16mm</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>30662-01</td>
+                     <td>1/4" to 1/8" Collet Adapter</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #42a44e" colspan="3">
+                        <b>Bosch Colt Spindle Mount Kit</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30287-01</td>
+                     <td>Spindle Mounting Plate</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30329-03</td>
+                     <td>Bosch Colt Spindle Mount</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30549-01</td>
+                     <td>Rubber Inventables Sticker</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25286-18</td>
+                     <td>Button Head Cap Screw M5 x 10</td>
+                     <td>2</td>
+                  </tr>
+                  <tr>
+                     <td>25287-08</td>
+                     <td>Flat Washer M5</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-37</td>
+                     <td>Socket Head Screw M5 x 20</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>25285-38</td>
+                     <td>Socket Head Screw M5 x 25</td>
+                     <td>1</td>
+                  </tr>
+                  <tr>
+                     <td>30555-01</td>
+                     <td>Split Lockwashers M5</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
+   <div class="panel-group" id="z-probe-accordion" role="tablist" aria-multiselectable="true">
+      <div class="panel panel-default">
+         <div data-toggle="collapse" data-parent="#z-probe-accordion" href="#z-probe" aria-expanded="false" aria-controls="z-probe" style="color:#fff;background:#000" class="panel-heading" role="tab" id="z-probe-header">
+            <h4 class="panel-title">
+               <strong>Z-Probe</strong>
+            </h4>
+            <div class="expand-icons">
+               <i class="fa fa-plus"></i>
+               <i class="fa fa-minus"></i>
+            </div>
+         </div>
+         <div id="z-probe" class="panel-collapse collapse" role="tabpanel" aria-labelledby="z-probe-header">
+            <div class="panel-body">
+               <table>
+                  <tr>
+                     <td style="color:#fff;background: #000" colspan="3">
+                        <b>Z-Probe</b>
+                     </td>
+                  </tr>
+                  <tr>
+                     <td><b>SKU</b></td>
+                     <td><b>Name</b></td>
+                     <td><b>Quantity</b></td>
+                  </tr>
+                  <tr>
+                     <td>30611-02</td>
+                     <td>Z-Probe Kit</td>
+                     <td>1</td>
+                  </tr>
+               </table>
+            </div>
+         </div>
+      </div>
+   </div>
 </div>

--- a/500mm/index.md
+++ b/500mm/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: 'Welcome!'
-step-number: 1
+step_number: 1
 permalink: /500mm/
 next-step: /500mm/step1/
 next-step-title: 'Work Area'

--- a/500mm/step1/index.md
+++ b/500mm/step1/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: "Work Area"
 step_number: 1
 permalink: /500mm/step1/
-next-step: /500mm/step2a/1sideplates/
-next-step-title: "Gantry"
+next_step: /500mm/step2a/1sideplates/
+next_step_title: "Gantry"
 ---
 <table>
   <tr>

--- a/500mm/step1/index.md
+++ b/500mm/step1/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Work Area"
-step-number: 1
+step_number: 1
 permalink: /500mm/step1/
 next-step: /500mm/step2a/1sideplates/
 next-step-title: "Gantry"

--- a/500mm/step10/index.md
+++ b/500mm/step10/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Computer Setup"
-step-number: 1
+step_number: 1
 permalink: /500mm/step10/
 ---
 

--- a/500mm/step2a/1sideplates/index.md
+++ b/500mm/step2a/1sideplates/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Gantry Side Plates"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/1sideplates/
 next-step: /500mm/step2a/2fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/500mm/step2a/1sideplates/index.md
+++ b/500mm/step2a/1sideplates/index.md
@@ -4,8 +4,8 @@ title: "Gantry Side Plates"
 parent: "Side Plates"
 step_number: 2
 permalink: /500mm/step2a/1sideplates/
-next-step: /500mm/step2a/2fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /500mm/step2a/2fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 ---
 
 <img src="../../step2/photo/jpfs_DSC2610.jpg">

--- a/500mm/step2a/2fixedvwheels/index.md
+++ b/500mm/step2a/2fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: Side Plates
 step_number: 2
 permalink: /500mm/step2a/2fixedvwheels/
-next-step: /500mm/step2a/3adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /500mm/step2a/3adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "fixedvwheels1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2564.jpg">

--- a/500mm/step2a/2fixedvwheels/index.md
+++ b/500mm/step2a/2fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Fixed V-Wheels"
 parent: Side Plates
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/2fixedvwheels/
 next-step: /500mm/step2a/3adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/500mm/step2a/3adjustablevwheels/index.md
+++ b/500mm/step2a/3adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Adjustable V-Wheels"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/3adjustablevwheels/
 next-step: /500mm/step2a/4idlers/
 next-step-title: "Idler Wheels"

--- a/500mm/step2a/3adjustablevwheels/index.md
+++ b/500mm/step2a/3adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: "Side Plates"
 step_number: 2
 permalink: /500mm/step2a/3adjustablevwheels/
-next-step: /500mm/step2a/4idlers/
-next-step-title: "Idler Wheels"
+next_step: /500mm/step2a/4idlers/
+next_step_title: "Idler Wheels"
 diagram: "adjustablevwheels1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2591.jpg">

--- a/500mm/step2a/4idlers/index.md
+++ b/500mm/step2a/4idlers/index.md
@@ -4,8 +4,8 @@ title: "Attach Idler Wheels"
 parent: "Side Plates"
 step_number: 2
 permalink: /500mm/step2a/4idlers/
-next-step: /500mm/step2a/5motors/
-next-step-title: "Stepper Motors"
+next_step: /500mm/step2a/5motors/
+next_step_title: "Stepper Motors"
 diagram: "idlers1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2597.jpg">

--- a/500mm/step2a/4idlers/index.md
+++ b/500mm/step2a/4idlers/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Idler Wheels"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/4idlers/
 next-step: /500mm/step2a/5motors/
 next-step-title: "Stepper Motors"

--- a/500mm/step2a/5motors/index.md
+++ b/500mm/step2a/5motors/index.md
@@ -4,8 +4,8 @@ title: "Attach Stepper Motors"
 parent: "Side Plates"
 step_number: 2
 permalink: /500mm/step2a/5motors/
-next-step: /500mm/step2a/6dragchain/
-next-step-title: "Drag Chain"
+next_step: /500mm/step2a/6dragchain/
+next_step_title: "Drag Chain"
 diagram: "motors1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2606.jpg">

--- a/500mm/step2a/5motors/index.md
+++ b/500mm/step2a/5motors/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Stepper Motors"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/5motors/
 next-step: /500mm/step2a/6dragchain/
 next-step-title: "Drag Chain"

--- a/500mm/step2a/6dragchain/index.md
+++ b/500mm/step2a/6dragchain/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Drag Chain Bracket"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/6dragchain/
 next-step: /500mm/step2a/7homeswitch/
 next-step-title: "Homing Switches"

--- a/500mm/step2a/6dragchain/index.md
+++ b/500mm/step2a/6dragchain/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Bracket"
 parent: "Side Plates"
 step_number: 2
 permalink: /500mm/step2a/6dragchain/
-next-step: /500mm/step2a/7homeswitch/
-next-step-title: "Homing Switches"
+next_step: /500mm/step2a/7homeswitch/
+next_step_title: "Homing Switches"
 diagram: "dragchain1.jpg"
 ---
 <img src="jpfsimage4.jpg">

--- a/500mm/step2a/7homeswitch/index.md
+++ b/500mm/step2a/7homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Homing Switches"
 parent: "Side Plates"
 step_number: 2
 permalink: /500mm/step2a/7homeswitch/
-next-step: /500mm/step2b/1xcarriage/
-next-step-title: "X-Carriage"
+next_step: /500mm/step2b/1xcarriage/
+next_step_title: "X-Carriage"
 diagram: "homeswitch1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2616.jpg">

--- a/500mm/step2a/7homeswitch/index.md
+++ b/500mm/step2a/7homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Homing Switches"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2a/7homeswitch/
 next-step: /500mm/step2b/1xcarriage/
 next-step-title: "X-Carriage"

--- a/500mm/step2b/1xcarriage/index.md
+++ b/500mm/step2b/1xcarriage/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Assemble X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/1xcarriage/
 next-step: /500mm/step2b/2idlers/
 next-step-title: "Idler Wheels"

--- a/500mm/step2b/1xcarriage/index.md
+++ b/500mm/step2b/1xcarriage/index.md
@@ -4,8 +4,8 @@ title: "Assemble X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/1xcarriage/
-next-step: /500mm/step2b/2idlers/
-next-step-title: "Idler Wheels"
+next_step: /500mm/step2b/2idlers/
+next_step_title: "Idler Wheels"
 ---
 
 In this section we'll be assembling The X-Carriage. This carriage carries the hardware for moving the X axis as well as the Z axis, though we'll be assembling the latter component in the next section

--- a/500mm/step2b/2idlers/index.md
+++ b/500mm/step2b/2idlers/index.md
@@ -4,8 +4,8 @@ title: "Attach Smooth Idlers"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/2idlers/
-next-step: /500mm/step2b/3fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /500mm/step2b/3fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 diagram: "idlers.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150151.jpg">

--- a/500mm/step2b/2idlers/index.md
+++ b/500mm/step2b/2idlers/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Smooth Idlers"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/2idlers/
 next-step: /500mm/step2b/3fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/500mm/step2b/3fixedvwheels/index.md
+++ b/500mm/step2b/3fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/3fixedvwheels/
-next-step: /500mm/step2b/4adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /500mm/step2b/4adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "fixedvwheels.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2641.jpg">

--- a/500mm/step2b/3fixedvwheels/index.md
+++ b/500mm/step2b/3fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Fixed V-Wheels"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/3fixedvwheels/
 next-step: /500mm/step2b/4adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/500mm/step2b/4adjustablevwheels/index.md
+++ b/500mm/step2b/4adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/4adjustablevwheels/
-next-step: /500mm/step2b/5motors/
-next-step-title: "Stepper Motors"
+next_step: /500mm/step2b/5motors/
+next_step_title: "Stepper Motors"
 diagram: "adjustablevwheels.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2648.jpg">

--- a/500mm/step2b/4adjustablevwheels/index.md
+++ b/500mm/step2b/4adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Adjustable V-Wheels"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/4adjustablevwheels/
 next-step: /500mm/step2b/5motors/
 next-step-title: "Stepper Motors"

--- a/500mm/step2b/5motors/index.md
+++ b/500mm/step2b/5motors/index.md
@@ -4,8 +4,8 @@ title: "Attach Stepper Motor to X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/5motors/
-next-step: /500mm/step2b/6dragchain/
-next-step-title: "Drag Chain Bracket"
+next_step: /500mm/step2b/6dragchain/
+next_step_title: "Drag Chain Bracket"
 diagram: "motors.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2652.jpg">

--- a/500mm/step2b/5motors/index.md
+++ b/500mm/step2b/5motors/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Stepper Motor to X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/5motors/
 next-step: /500mm/step2b/6dragchain/
 next-step-title: "Drag Chain Bracket"

--- a/500mm/step2b/6dragchain/index.md
+++ b/500mm/step2b/6dragchain/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Drag Chain Bracket To X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/6dragchain/
 next-step: /500mm/step2b/7homeswitch/
 next-step-title: "Homing Switch"

--- a/500mm/step2b/6dragchain/index.md
+++ b/500mm/step2b/6dragchain/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Bracket To X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/6dragchain/
-next-step: /500mm/step2b/7homeswitch/
-next-step-title: "Homing Switch"
+next_step: /500mm/step2b/7homeswitch/
+next_step_title: "Homing Switch"
 diagram: "dragchain.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150160.jpg">

--- a/500mm/step2b/7homeswitch/index.md
+++ b/500mm/step2b/7homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Home Switch to X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /500mm/step2b/7homeswitch/
-next-step: /500mm/step2c/1zaxis/
-next-step-title: "Z-Axis"
+next_step: /500mm/step2c/1zaxis/
+next_step_title: "Z-Axis"
 diagram: "homeswitch.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150166.jpg">

--- a/500mm/step2b/7homeswitch/index.md
+++ b/500mm/step2b/7homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Home Switch to X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /500mm/step2b/7homeswitch/
 next-step: /500mm/step2c/1zaxis/
 next-step-title: "Z-Axis"

--- a/500mm/step2c/01zaxis/index.md
+++ b/500mm/step2c/01zaxis/index.md
@@ -4,8 +4,8 @@ title: "Z-Axis"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/1zaxis/
-next-step: /500mm/step2c/2flangedbearing/
-next-step-title: "Flanged Bearing"
+next_step: /500mm/step2c/2flangedbearing/
+next_step_title: "Flanged Bearing"
 ---
 
 In this section we'll assemble the Z-Axis rail, leadscrew, and spindle mount. This assembly will be attached to the X-Carriage.

--- a/500mm/step2c/01zaxis/index.md
+++ b/500mm/step2c/01zaxis/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Z-Axis"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/1zaxis/
 next-step: /500mm/step2c/2flangedbearing/
 next-step-title: "Flanged Bearing"

--- a/500mm/step2c/02flangedbearing/index.md
+++ b/500mm/step2c/02flangedbearing/index.md
@@ -4,8 +4,8 @@ title: "Attach Flanged Bearing to Z-Axis Plate"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/2flangedbearing/
-next-step: /500mm/step2c/3attachrail/
-next-step-title: "Z-Axis Rail"
+next_step: /500mm/step2c/3attachrail/
+next_step_title: "Z-Axis Rail"
 diagram: "../02flangedbearing/flangedbearing.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2684.jpg">

--- a/500mm/step2c/02flangedbearing/index.md
+++ b/500mm/step2c/02flangedbearing/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Flanged Bearing to Z-Axis Plate"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/2flangedbearing/
 next-step: /500mm/step2c/3attachrail/
 next-step-title: "Z-Axis Rail"

--- a/500mm/step2c/03attachrail/index.md
+++ b/500mm/step2c/03attachrail/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Z-Axis Rail"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/3attachrail/
 next-step: /500mm/step2c/4leadscrew/
 next-step-title: "Leadscrew"

--- a/500mm/step2c/03attachrail/index.md
+++ b/500mm/step2c/03attachrail/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Rail"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/3attachrail/
-next-step: /500mm/step2c/4leadscrew/
-next-step-title: "Leadscrew"
+next_step: /500mm/step2c/4leadscrew/
+next_step_title: "Leadscrew"
 diagram: "../03attachrail/attachrail.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2687.jpg">

--- a/500mm/step2c/04leadscrew/index.md
+++ b/500mm/step2c/04leadscrew/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Install Leadscrew"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/4leadscrew/
 next-step: /500mm/step2c/5attachtocarriage/
 next-step-title: "Attach Z-Axis"

--- a/500mm/step2c/04leadscrew/index.md
+++ b/500mm/step2c/04leadscrew/index.md
@@ -4,8 +4,8 @@ title: "Install Leadscrew"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/4leadscrew/
-next-step: /500mm/step2c/5attachtocarriage/
-next-step-title: "Attach Z-Axis"
+next_step: /500mm/step2c/5attachtocarriage/
+next_step_title: "Attach Z-Axis"
 diagram: "../04leadscrew/leadscrew.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2705.jpg">

--- a/500mm/step2c/05attachtocarriage/index.md
+++ b/500mm/step2c/05attachtocarriage/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Assembly to X-Carriage"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/5attachtocarriage/
-next-step: /500mm/step2c/6adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /500mm/step2c/6adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "../05attachtocarriage/attachtocarriage1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2723.jpg">

--- a/500mm/step2c/05attachtocarriage/index.md
+++ b/500mm/step2c/05attachtocarriage/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Z-Axis Assembly to X-Carriage"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/5attachtocarriage/
 next-step: /500mm/step2c/6adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/500mm/step2c/06adjustablevwheels/index.md
+++ b/500mm/step2c/06adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/6adjustablevwheels/
-next-step: /500mm/step2c/7fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /500mm/step2c/7fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 diagram: "../06adjustablevwheels/adjustablevwheels3.jpg"
 ---
 

--- a/500mm/step2c/06adjustablevwheels/index.md
+++ b/500mm/step2c/06adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Adjustable V-Wheels"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/6adjustablevwheels/
 next-step: /500mm/step2c/7fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/500mm/step2c/07fixedvwheels/index.md
+++ b/500mm/step2c/07fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Fixed V-Wheels"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/7fixedvwheels/
 next-step: /500mm/step2c/8clampbolts/
 next-step-title: "Clamp Bolts"

--- a/500mm/step2c/07fixedvwheels/index.md
+++ b/500mm/step2c/07fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/7fixedvwheels/
-next-step: /500mm/step2c/8clampbolts/
-next-step-title: "Clamp Bolts"
+next_step: /500mm/step2c/8clampbolts/
+next_step_title: "Clamp Bolts"
 diagram: "../07fixedvwheels/fixedvwheels3.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2749.jpg">

--- a/500mm/step2c/08clampbolts/index.md
+++ b/500mm/step2c/08clampbolts/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Insert Spindle Carriage Clamping Bolts"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/8clampbolts/
 next-step: /500mm/step2c/9attachmount/
 next-step-title: "Attach Spindle Mount"

--- a/500mm/step2c/08clampbolts/index.md
+++ b/500mm/step2c/08clampbolts/index.md
@@ -4,8 +4,8 @@ title: "Insert Spindle Carriage Clamping Bolts"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/8clampbolts/
-next-step: /500mm/step2c/9attachmount/
-next-step-title: "Attach Spindle Mount"
+next_step: /500mm/step2c/9attachmount/
+next_step_title: "Attach Spindle Mount"
 diagram: "../08clampbolts/clampbolts.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2750.jpg">

--- a/500mm/step2c/09attachmount/index.md
+++ b/500mm/step2c/09attachmount/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Spindle Carriage to Z-Axis"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/9attachmount/
 next-step: /500mm/step2c/10homeswitch/
 next-step-title: "Z-Axis Homing Switch"

--- a/500mm/step2c/09attachmount/index.md
+++ b/500mm/step2c/09attachmount/index.md
@@ -4,8 +4,8 @@ title: "Attach Spindle Carriage to Z-Axis"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/9attachmount/
-next-step: /500mm/step2c/10homeswitch/
-next-step-title: "Z-Axis Homing Switch"
+next_step: /500mm/step2c/10homeswitch/
+next_step_title: "Z-Axis Homing Switch"
 diagram: "../09attachmount/attachmount1.jpg"
 diagram2: "../09attachmount/attachmount2.jpg"
 ---

--- a/500mm/step2c/10homeswitch/index.md
+++ b/500mm/step2c/10homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Z-Axis Home Switch"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /500mm/step2c/10homeswitch/
 next-step: /500mm/step2d/1gantryrail/
 next-step-title: "Assemble Gantry"

--- a/500mm/step2c/10homeswitch/index.md
+++ b/500mm/step2c/10homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Home Switch"
 parent: Z-Axis
 step_number: 2
 permalink: /500mm/step2c/10homeswitch/
-next-step: /500mm/step2d/1gantryrail/
-next-step-title: "Assemble Gantry"
+next_step: /500mm/step2d/1gantryrail/
+next_step_title: "Assemble Gantry"
 ---
 
 <table>

--- a/500mm/step2d/1gantryrail/index.md
+++ b/500mm/step2d/1gantryrail/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Gantry"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2d/1gantryrail/
 next-step: /500mm/step2d/2attachsideplate/
 next-step-title: "Attach First Plate"

--- a/500mm/step2d/1gantryrail/index.md
+++ b/500mm/step2d/1gantryrail/index.md
@@ -4,8 +4,8 @@ title: "Gantry"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /500mm/step2d/1gantryrail/
-next-step: /500mm/step2d/2attachsideplate/
-next-step-title: "Attach First Plate"
+next_step: /500mm/step2d/2attachsideplate/
+next_step_title: "Attach First Plate"
 ---
 We will now assemble the main gantry of the machine using the sub-assemblies you've built thus far. After this is assembled, your machine's frame will almost be complete.
 

--- a/500mm/step2d/2attachsideplate/index.md
+++ b/500mm/step2d/2attachsideplate/index.md
@@ -4,8 +4,8 @@ title: "Attach Side Plate"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /500mm/step2d/2attachsideplate/
-next-step: /500mm/step2d/3attachcarriage/
-next-step-title: "Attach Carriage"
+next_step: /500mm/step2d/3attachcarriage/
+next_step_title: "Attach Carriage"
 ---
 
 <table>

--- a/500mm/step2d/2attachsideplate/index.md
+++ b/500mm/step2d/2attachsideplate/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Side Plate"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2d/2attachsideplate/
 next-step: /500mm/step2d/3attachcarriage/
 next-step-title: "Attach Carriage"

--- a/500mm/step2d/3attachcarriage/index.md
+++ b/500mm/step2d/3attachcarriage/index.md
@@ -4,8 +4,8 @@ title: "Attach X-Carriage Assembly"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /500mm/step2d/3attachcarriage/
-next-step: /500mm/step2d/4attachsideplate/
-next-step-title: "Side Plate"
+next_step: /500mm/step2d/4attachsideplate/
+next_step_title: "Side Plate"
 ---
 
 

--- a/500mm/step2d/3attachcarriage/index.md
+++ b/500mm/step2d/3attachcarriage/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach X-Carriage Assembly"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2d/3attachcarriage/
 next-step: /500mm/step2d/4attachsideplate/
 next-step-title: "Side Plate"

--- a/500mm/step2d/4attachsideplate/index.md
+++ b/500mm/step2d/4attachsideplate/index.md
@@ -4,8 +4,8 @@ title: "Gantry"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /500mm/step2d/4attachsideplate/
-next-step: /500mm/step2d/5dragchainrail/
-next-step-title: "Drag Chain Rail"
+next_step: /500mm/step2d/5dragchainrail/
+next_step_title: "Drag Chain Rail"
 ---
 
 <table>

--- a/500mm/step2d/4attachsideplate/index.md
+++ b/500mm/step2d/4attachsideplate/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Gantry"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2d/4attachsideplate/
 next-step: /500mm/step2d/5dragchainrail/
 next-step-title: "Drag Chain Rail"

--- a/500mm/step2d/5dragchainrail/index.md
+++ b/500mm/step2d/5dragchainrail/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Rail"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /500mm/step2d/5dragchainrail/
-next-step: /500mm/step3/
-next-step-title: "Rails"
+next_step: /500mm/step3/
+next_step_title: "Rails"
 ---
 
 <table>

--- a/500mm/step2d/5dragchainrail/index.md
+++ b/500mm/step2d/5dragchainrail/index.md
@@ -2,7 +2,7 @@
 layout: default500mm
 title: "Attach Drag Chain Rail"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /500mm/step2d/5dragchainrail/
 next-step: /500mm/step3/
 next-step-title: "Rails"

--- a/500mm/step3/index.md
+++ b/500mm/step3/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Rails"
-step-number: 1
+step_number: 1
 permalink: /500mm/step3/
 next-step: /500mm/step4/
 next-step-title: "Belting"

--- a/500mm/step3/index.md
+++ b/500mm/step3/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: "Rails"
 step_number: 1
 permalink: /500mm/step3/
-next-step: /500mm/step4/
-next-step-title: "Belting"
+next_step: /500mm/step4/
+next_step_title: "Belting"
 ---
 In this step, you'll be assembling the main y axis rails and attaching them to the gantry. You'll then attach this assembly to the work area.
 

--- a/500mm/step4/index.md
+++ b/500mm/step4/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: "Belting"
 step_number: 1
 permalink: /500mm/step4/
-next-step: /500mm/step5/
-next-step-title: "Spindle"
+next_step: /500mm/step5/
+next_step_title: "Spindle"
 ---
 <p>This section covers installing the belting.</p>
 <table>

--- a/500mm/step4/index.md
+++ b/500mm/step4/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Belting"
-step-number: 1
+step_number: 1
 permalink: /500mm/step4/
 next-step: /500mm/step5/
 next-step-title: "Spindle"

--- a/500mm/step5/index.md
+++ b/500mm/step5/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Spindle"
-step-number: 1
+step_number: 1
 permalink: /500mm/step5/
 next-step: /500mm/step6/
 next-step-title: "Wiring"

--- a/500mm/step5/index.md
+++ b/500mm/step5/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: "Spindle"
 step_number: 1
 permalink: /500mm/step5/
-next-step: /500mm/step6/
-next-step-title: "Wiring"
+next_step: /500mm/step6/
+next_step_title: "Wiring"
 ---
 In this step you'll be mounting a DeWalt 611 router in the spindle mount. Begin by removing existing base and collar from the spindle. This will leave just the metal router body.
 <img src="photo/jpfs_DSC2846.jpg">

--- a/500mm/step6/index.md
+++ b/500mm/step6/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: "Wiring"
 step_number: 6
 permalink: /500mm/step6/
-next-step: /500mm/step7/
-next-step-title: "Side Board"
+next_step: /500mm/step7/
+next_step_title: "Side Board"
 diagram: "wiringDiagram500.jpg"
 ---
 

--- a/500mm/step6/index.md
+++ b/500mm/step6/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Wiring"
-step-number: 6
+step_number: 6
 permalink: /500mm/step6/
 next-step: /500mm/step7/
 next-step-title: "Side Board"

--- a/500mm/step7/index.md
+++ b/500mm/step7/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title: "Side Board"
 step_number: 1
 permalink: /500mm/step7/
-next-step: /500mm/step8/
-next-step-title: "X-Controller"
+next_step: /500mm/step8/
+next_step_title: "X-Controller"
 ---
 <table>
   <tr>

--- a/500mm/step7/index.md
+++ b/500mm/step7/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title: "Side Board"
-step-number: 1
+step_number: 1
 permalink: /500mm/step7/
 next-step: /500mm/step8/
 next-step-title: "X-Controller"

--- a/500mm/step8/index.md
+++ b/500mm/step8/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title:  "X-Controller"
 step_number: 1
 permalink: /500mm/step8/
-next-step: /500mm/step9/
-next-step-title: "Calibrate"
+next_step: /500mm/step9/
+next_step_title: "Calibrate"
 ---
 
 <img src="PB231421BATCH201.jpg">

--- a/500mm/step8/index.md
+++ b/500mm/step8/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title:  "X-Controller"
-step-number: 1
+step_number: 1
 permalink: /500mm/step8/
 next-step: /500mm/step9/
 next-step-title: "Calibrate"

--- a/500mm/step9/index.md
+++ b/500mm/step9/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default500mm
 title:  "Calibrate"
-step-number: 1
+step_number: 1
 permalink: /500mm/step9/
 next-step: /500mm/step10/
 next-step-title: "Computer Setup"

--- a/500mm/step9/index.md
+++ b/500mm/step9/index.md
@@ -3,8 +3,8 @@ layout: default500mm
 title:  "Calibrate"
 step_number: 1
 permalink: /500mm/step9/
-next-step: /500mm/step10/
-next-step-title: "Computer Setup"
+next_step: /500mm/step10/
+next_step_title: "Computer Setup"
 ---
 
 

--- a/750mm/index.md
+++ b/750mm/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: 'Welcome!'
 step_number: 1
 permalink: /750mm/
-next-step: /750mm/step1/
-next-step-title: 'Work Area'
+next_step: /750mm/step1/
+next_step_title: 'Work Area'
 ---
 
 <img src="750_angle_0092.jpg">

--- a/750mm/index.md
+++ b/750mm/index.md
@@ -1,23 +1,23 @@
 ---
 layout: default750mm
-title: "Welcome!"
+title: 'Welcome!'
 step-number: 1
 permalink: /750mm/
 next-step: /750mm/step1/
-next-step-title: "Work Area"
+next-step-title: 'Work Area'
 ---
 
 <img src="750_angle_0092.jpg">
 
-Congratulations!  You've just taken one of your first steps into the world of 3D Carving!  This guide will take you through the steps of building your very own X-Carve 3D Carver! We've tried to make it as easy as possible to get you from unpacking your parts to carving.  We've laid out the instructions starting from the bottom of the machine to the top, and we will cover everything from machine assembly to computer setup.
+Congratulations! You've just taken one of your first steps into the world of 3D Carving! This guide will take you through the steps of building your very own X-Carve 3D Carver! We've tried to make it as easy as possible to get you from unpacking your parts to carving. We've laid out the instructions starting from the bottom of the machine to the top, and we will cover everything from machine assembly to computer setup.
 
-This is a do-it-yourself 3D carving kit: the more time and attention you put into assembling your machine, the better it will perform.  If you run into any trouble during assembly or carving you can find further help from the wonderful community on the forum, our support center which is continuously growing with articles and tutorials, and as always you can reach our customer success team through our [support center](https://inventables.desk.com/) or by phone at 312 775 7009.
+This is a do-it-yourself 3D carving kit: the more time and attention you put into assembling your machine, the better it will perform. If you run into any trouble during assembly or carving you can find further help from the wonderful community on the forum, our support center which is continuously growing with articles and tutorials, and as always you can reach our customer success team through our [support center](https://inventables.desk.com/) or by phone at 312 775 7009.
 
 The X-Carve is open source hardware. We have 3D models and drawings available in a GrabCAD repository <a href="https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcojYwyy_VqboQQ-9hKBJrjS3zGaGuue8sfnqRNxGI9WQS">here</a>.
 
 <h2>Recommended tools</h2>
 
-If you purchased a tool kit with your machine, most of these should be included with the exception of power tools 
+If you purchased a tool kit with your machine, most of these should be included with the exception of power tools
 
 - 7mm wrench or socket
 - 8mm wrench or socket
@@ -33,1669 +33,958 @@ If you purchased a tool kit with your machine, most of these should be included 
 
 <h2>Bill of Materials</h2>
 <div class="bom">
-<div class="panel-group" id="core-components-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#core-components-accordion" href="#core-components" aria-expanded="false" aria-controls="core-components" style="color:#fff;background:#383838" class="panel-heading" role="tab" id="core-components-header">
-<h4 class="panel-title">
-<strong>Core Components</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="core-components" class="panel-collapse collapse" role="tabpanel" aria-labelledby="core-components-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #383838" colspan="3">
-      <b>Core Components Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30524-01
-    </td>
-    <td>
-      MakerSlide End Plate
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30525-01
-    </td>
-    <td>
-      Gantry Side Plate
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30526-01
-    </td>
-    <td>
-      Belt Clip
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30677-01
-    </td>
-    <td>
-      Belt Sleeve Clip
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30396-02
-    </td>
-    <td>
-      ACME Lead Screw
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25195-07
-    </td>
-    <td>
-      Eccentric Spacer 0.200" Long
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25195-08
-    </td>
-    <td>
-      Eccentric Spacer 0.375" Long
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30534-01
-    </td>
-    <td>
-      Z Axis Motor Plate
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-12
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      18
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26054-04
-    </td>
-    <td>
-      Aluminum GT2 Pulley 20T 8mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25280-03
-    </td>
-    <td>
-      Delrin Nut ACME 3/8-12
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30547-01
-    </td>
-    <td>
-      GT2 Belt Closed Loop, 80T
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25312-23
-    </td>
-    <td>
-      Aluminum Spacer 5.1mm ID 9.5mm OD 9.5mm LG
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-11
-    </td>
-    <td>
-      Flat Washer M8
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30545-01
-    </td>
-    <td>
-      X Carriage Extrusion
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25142-09
-    </td>
-    <td>
-      MakerSlide 200mm Tapped Black
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25203-01
-    </td>
-    <td>
-      V Wheel Assembly
-    </td>
-    <td>
-      20
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25197-01
-    </td>
-    <td>
-      Smooth Idler Pulley Assembly
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-33
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 8
-    </td>
-    <td>
-      16
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-35
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-38
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      16
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-46
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-43
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 25
-    </td>
-    <td>
-      11
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-49
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 30
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-48
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 40
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30169-01
-    </td>
-    <td>
-      Flanged Bearing, 8mm
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30552-05
-    </td>
-    <td>
-      Flat Head Screw M5 x 35
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-12
-    </td>
-    <td>
-      M5 Flat Washer
-    </td>
-    <td>
-      26
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-09
-    </td>
-    <td>
-      Nylon Insert Lock Nut M5
-    </td>
-    <td>
-      41
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-05
-    </td>
-    <td>
-      Nylon Insert Lock Nut M6
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-54
-    </td>
-    <td>
-      Socket Head Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-52
-    </td>
-    <td>
-      Socket Head Screw M5 x 16
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-53
-    </td>
-    <td>
-      Socket Head Screw M5 x 20
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30711-01
-    </td>
-    <td>
-      Lubricant
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
-<h4 class="panel-title">
-<strong>Rail Size</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="rail-size" class="panel-collapse collapse" role="tabpanel" aria-labelledby="rail-size-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#000;background: #FFFFFF" colspan="3">
-      <b>750mm Rail Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-10
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26018-01
-    </td>
-    <td>
-      Extrusion Bracket (Gusset)
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-02
-    </td>
-    <td>
-      X-Carve Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26053-01
-    </td>
-    <td>
-      GT2 Belting - Open Ended (feet)
-    </td>
-    <td>
-      9
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-05
-    </td>
-    <td>
-      Aluminum Extrusion 20mm × 20mm Black 708mm Lg
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-06
-    </td>
-    <td>
-      Aluminum Extrusion 20mm × 20mm Black 750mm Lg
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25142-12
-    </td>
-    <td>
-      MakerSlide 750mm Tapped Black
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30678-02
-    </td>
-    <td>
-      MakerSlide Extra Wide 750mm Tapped Black
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-36
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="motors-and-wiring-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#motors-and-wiring-accordion" href="#motors-and-wiring" aria-expanded="false" aria-controls="motors-and-wiring" style="color:#fff;background:#CC3440" class="panel-heading" role="tab" id="motors-and-wiring-header">
-<h4 class="panel-title">
-<strong>Motors and Wiring</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="motors-and-wiring" class="panel-collapse collapse" role="tabpanel" aria-labelledby="motors-and-wiring-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #CC3440" colspan="3">
-      <b>750mm Motor and Wiring Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25311-06
-    </td>
-    <td>
-      Stepper Motor - NEMA 23
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-05
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 73 in long (X-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-06
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 34 in long (Y1-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-07
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 71 in long (Y2-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30679-08
-    </td>
-    <td>
-      Cable Assembly, Stepper Motor 73 in long (Z-Axis)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="drag-chain-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#drag-chain-accordion" href="#drag-chain" aria-expanded="false" aria-controls="drag-chain" style="color:#fff;background:#8A52A1" class="panel-heading" role="tab" id="drag-chain-header">
-<h4 class="panel-title">
-<strong>Drag Chain</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="drag-chain" class="panel-collapse collapse" role="tabpanel" aria-labelledby="drag-chain-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #8A52A1" colspan="3">
-      <b>750mm Drag Chain Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30527-05
-    </td>
-    <td>
-      Drag Chain Bracket
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30527-06
-    </td>
-    <td>
-      Drag Chain Bracket
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30680-01
-    </td>
-    <td>
-      Zip Tie Mount
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26016-03
-    </td>
-    <td>
-      T-Nut M5 Post Assembly
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30681-01
-    </td>
-    <td>
-      Drag Chain Support Arm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30331-12
-    </td>
-    <td>
-      Drag Chain 18x25 16 Links w/ Custom Ends
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25986-03
-    </td>
-    <td>
-      Cable Tie 4" (100 Pack)
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-08
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 750mm Tapped
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-44
-    </td>
-    <td>
-      Button Head Cap Screw M4 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-31
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 6
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-46
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30554-06
-    </td>
-    <td>
-      Flat Head Cap Screw M5 x 10
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30554-07
-    </td>
-    <td>
-      Flat Head Cap Screw M5 x 12
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-08
-    </td>
-    <td>
-      Hex Nut M4 Nylon Locking
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-10
-    </td>
-    <td>
-      Hex Nut M5 Nylon Locking
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="home-switch-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#home-switch-accordion" href="#home-switch" aria-expanded="false" aria-controls="home-switch" style="color:#fff;background:#F47B44" class="panel-heading" role="tab" id="home-switch-header">
-<h4 class="panel-title">
-<strong>Home Switch</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="home-switch" class="panel-collapse collapse" role="tabpanel" aria-labelledby="home-switch-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #F47B44" colspan="3">
-      <b>750mm Homing Switch Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30557-02
-    </td>
-    <td>
-      Microswitch
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26016-03
-    </td>
-    <td>
-      Post-Assembly M5 T-Slot Nuts
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-04
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 76"Lg X-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-05
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 39"Lg Y-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30682-06
-    </td>
-    <td>
-      Cable Assembly, 2C Lugs Ferrules 76"Lg Z-Limit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25312-25
-    </td>
-    <td>
-      Spacer 5.1mm ID 9.5mm 10.5mm Lg Aluminum
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25284-12
-    </td>
-    <td>
-      Hex Nut M2x0.4
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30265-07
-    </td>
-    <td>
-      Hex Nut M3 Nylon Locking
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-56
-    </td>
-    <td>
-      Socket Head Screw M2 x 10
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-57
-    </td>
-    <td>
-      Socket Head Screw M2 x 14
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-44
-    </td>
-    <td>
-      Socket Head Screw M3 x 20
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-51
-    </td>
-    <td>
-      Socket Head Screw M5 x 16
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30555-03
-    </td>
-    <td>
-      Washer, Split Lock M2 Stainless
-    </td>
-    <td>
-      6
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="waste-board-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#waste-board-accordion" href="#waste-board" aria-expanded="false" aria-controls="waste-board" style="color:#fff;background:#0a91d1" class="panel-heading" role="tab" id="waste-board-header">
-<h4 class="panel-title">
-<strong>Waste Board</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="waste-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="waste-board-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #0a91d1" colspan="3">
-      <b>750mm Waste Board Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-10
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30517-08
-    </td>
-    <td>
-      Threaded Insert M5 x 10
-    </td>
-    <td>
-      64
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30683-01
-    </td>
-    <td>
-      750mm Waste Board
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-40
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="side-board-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#side-board-accordion" href="#side-board" aria-expanded="false" aria-controls="side-board" style="color:#fff;background:#9D9FA2" class="panel-heading" role="tab" id="side-board-header">
-<h4 class="panel-title">
-<strong>Side Board</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="side-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="side-board-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #9D9FA2" colspan="3">
-      <b>750mm Side Board Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30684-01
-    </td>
-    <td>
-      Extrusion Connection Bracket
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25281-13
-    </td>
-    <td>
-      T-Slot Nut M5 Pre-Assembly
-    </td>
-    <td>
-      21
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26018-01
-    </td>
-    <td>
-      Cast Corner Bracket, Clear
-    </td>
-    <td>
-      4
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30517-11
-    </td>
-    <td>
-      Threaded Insert M5
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30685-02
-    </td>
-    <td>
-      Side Board, X-Carve 750mm Size
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-10
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 250mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      26049-05
-    </td>
-    <td>
-      Extrusion T-Slot 20x20 x 708mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-34
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 8
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-37
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      8
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-41
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 12
-    </td>
-    <td>
-      5
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-47
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 14
-    </td>
-    <td>
-      12
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="spindle-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#spindle-accordion" href="#spindle" aria-expanded="false" aria-controls="spindle" style="color:#fff;background:#42a44e" class="panel-heading" role="tab" id="spindle-header">
-<h4 class="panel-title">
-<strong>Spindle</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="spindle" class="panel-collapse collapse" role="tabpanel" aria-labelledby="spindle-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>110V DeWalt 611 Spindle and Mount</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30621-01
-    </td>
-    <td>
-      DeWalt 611 Router
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>240V DeWalt 611 Spindle and Mount</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30621-02
-    </td>
-    <td>
-      240V DeWalt 26200 router
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>X-Carve DeWalt 611 Spindle Mount (Does Not Include Spindle)</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30610-01
-    </td>
-    <td>
-      X-Carve DeWalt 611 Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-55
-    </td>
-    <td>
-      Socket Head Cap Screw M4 x 16mm Low Profile
-    </td>
-    <td>
-      3
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30558-01
-    </td>
-    <td>
-      Inventables Label
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-45
-    </td>
-    <td>
-      Button Head Cap Screw M5 × 16mm
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30662-01
-    </td>
-    <td>
-      1/4" to 1/8" Collet Adapter
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-<table>
-  <tr>
-    <td style="color:#fff;background: #42a44e" colspan="3">
-      <b>Bosch Colt Spindle Mount Kit</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30287-01
-    </td>
-    <td>
-      Spindle Mounting Plate
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30329-03
-    </td>
-    <td>
-      Bosch Colt Spindle Mount
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30549-01
-    </td>
-    <td>
-      Rubber Inventables Sticker
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25286-18
-    </td>
-    <td>
-      Button Head Cap Screw M5 x 10
-    </td>
-    <td>
-      2
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25287-08
-    </td>
-    <td>
-      Flat Washer M5
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-37
-    </td>
-    <td>
-      Socket Head Screw M5 x 20
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      25285-38
-    </td>
-    <td>
-      Socket Head Screw M5 x 25
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30555-01
-    </td>
-    <td>
-      Split Lockwashers M5
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="panel-group" id="z-probe-accordion" role="tablist" aria-multiselectable="true">
-<div class="panel panel-default">
-<a data-toggle="collapse" data-parent="#z-probe-accordion" href="#z-probe" aria-expanded="false" aria-controls="z-probe" style="color:#fff;background:#000" class="panel-heading" role="tab" id="z-probe-header">
-<h4 class="panel-title">
-<strong>Z-Probe</strong>
-</h4>
-<div class="expand-icons">
-<i class="fa fa-plus"></i>
-<i class="fa fa-minus"></i>
-</div>
-</a>
-<div id="z-probe" class="panel-collapse collapse" role="tabpanel" aria-labelledby="z-probe-header">
-<div class="panel-body">
-
-<table>
-  <tr>
-    <td style="color:#fff;background: #000" colspan="3">
-      <b>Z-Probe</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      <b>SKU</b>
-    </td>
-    <td>
-      <b>Name</b>
-    </td>
-    <td>
-      <b>Quantity</b>
-    </td>
-  </tr>
-  <tr>
-    <td>
-      30611-02
-    </td>
-    <td>
-      Z-Probe Kit
-    </td>
-    <td>
-      1
-    </td>
-  </tr>
-</table>
-</div>
-</div>
-</div>
-</div>
+	<div class="panel-group" id="core-components-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#core-components-accordion" href="#core-components" aria-expanded="false" aria-controls="core-components" style="color:#fff;background:#383838" class="panel-heading" role="tab" id="core-components-header">
+				<h4 class="panel-title">
+					<strong>Core Components</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="core-components" class="panel-collapse collapse" role="tabpanel" aria-labelledby="core-components-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #383838" colspan="3">
+								<b>Core Components Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30524-01</td>
+							<td>MakerSlide End Plate</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>30525-01</td>
+							<td>Gantry Side Plate</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30526-01</td>
+							<td>Belt Clip</td>
+							<td>6</td>
+						</tr>
+						<tr>
+							<td>30677-01</td>
+							<td>Belt Sleeve Clip</td>
+							<td>6</td>
+						</tr>
+						<tr>
+							<td>30396-02</td>
+							<td>ACME Lead Screw</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25195-07</td>
+							<td>Eccentric Spacer 0.200" Long</td>
+							<td>8</td>
+						</tr>
+						<tr>
+							<td>25195-08</td>
+							<td>Eccentric Spacer 0.375" Long</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30534-01</td>
+							<td>Z Axis Motor Plate</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25281-12</td>
+							<td>T-Slot Nut M5 Pre-Assembly</td>
+							<td>18</td>
+						</tr>
+						<tr>
+							<td>26054-04</td>
+							<td>Aluminum GT2 Pulley 20T 8mm</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25280-03</td>
+							<td>Delrin Nut ACME 3/8-12</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30547-01</td>
+							<td>GT2 Belt Closed Loop, 80T</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25312-23</td>
+							<td>Aluminum Spacer 5.1mm ID 9.5mm OD 9.5mm LG</td>
+							<td>8</td>
+						</tr>
+						<tr>
+							<td>25287-11</td>
+							<td>Flat Washer M8</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30545-01</td>
+							<td>X Carriage Extrusion</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25142-09</td>
+							<td>MakerSlide 200mm Tapped Black</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25203-01</td>
+							<td>V Wheel Assembly</td>
+							<td>20</td>
+						</tr>
+						<tr>
+							<td>25197-01</td>
+							<td>Smooth Idler Pulley Assembly</td>
+							<td>6</td>
+						</tr>
+						<tr>
+							<td>25286-33</td>
+							<td>Button Head Cap Screw M5 x 8</td>
+							<td>16</td>
+						</tr>
+						<tr>
+							<td>25286-35</td>
+							<td>Button Head Cap Screw M5 x 10</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>25286-38</td>
+							<td>Button Head Cap Screw M5 x 12</td>
+							<td>16</td>
+						</tr>
+						<tr>
+							<td>25286-46</td>
+							<td>Button Head Cap Screw M5 x 14</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25286-43</td>
+							<td>Button Head Cap Screw M5 x 25</td>
+							<td>11</td>
+						</tr>
+						<tr>
+							<td>25286-49</td>
+							<td>Button Head Cap Screw M5 x 30</td>
+							<td>12</td>
+						</tr>
+						<tr>
+							<td>25286-48</td>
+							<td>Button Head Cap Screw M5 x 40</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>30169-01</td>
+							<td>Flanged Bearing, 8mm</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30552-05</td>
+							<td>Flat Head Screw M5 x 35</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25287-12</td>
+							<td>M5 Flat Washer</td>
+							<td>26</td>
+						</tr>
+						<tr>
+							<td>30265-09</td>
+							<td>Nylon Insert Lock Nut M5</td>
+							<td>41</td>
+						</tr>
+						<tr>
+							<td>30265-05</td>
+							<td>Nylon Insert Lock Nut M6</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-54</td>
+							<td>Socket Head Screw M5 x 10</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>25285-52</td>
+							<td>Socket Head Screw M5 x 16</td>
+							<td>8</td>
+						</tr>
+						<tr>
+							<td>25285-53</td>
+							<td>Socket Head Screw M5 x 20</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>30711-01</td>
+							<td>Lubricant</td>
+							<td>1</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
+				<h4 class="panel-title">
+					<strong>Rail Size</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="rail-size" class="panel-collapse collapse" role="tabpanel" aria-labelledby="rail-size-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#000;background: #FFFFFF" colspan="3">
+								<b>750mm Rail Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>25281-10</td>
+							<td>T-Slot Nut M5 Pre-Assembly</td>
+							<td>12</td>
+						</tr>
+						<tr>
+							<td>26018-01</td>
+							<td>Extrusion Bracket (Gusset)</td>
+							<td>6</td>
+						</tr>
+						<tr>
+							<td>30558-02</td>
+							<td>X-Carve Label</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>26053-01</td>
+							<td>GT2 Belting - Open Ended (feet)</td>
+							<td>9</td>
+						</tr>
+						<tr>
+							<td>26049-05</td>
+							<td>Aluminum Extrusion 20mm × 20mm Black 708mm Lg</td>
+							<td>3</td>
+						</tr>
+						<tr>
+							<td>26049-06</td>
+							<td>Aluminum Extrusion 20mm × 20mm Black 750mm Lg</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25142-12</td>
+							<td>MakerSlide 750mm Tapped Black</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30678-02</td>
+							<td>MakerSlide Extra Wide 750mm Tapped Black</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25286-36</td>
+							<td>Button Head Cap Screw M5 x 10</td>
+							<td>12</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="motors-and-wiring-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#motors-and-wiring-accordion" href="#motors-and-wiring" aria-expanded="false" aria-controls="motors-and-wiring" style="color:#fff;background:#CC3440" class="panel-heading" role="tab" id="motors-and-wiring-header">
+				<h4 class="panel-title">
+					<strong>Motors and Wiring</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="motors-and-wiring" class="panel-collapse collapse" role="tabpanel" aria-labelledby="motors-and-wiring-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #CC3440" colspan="3">
+								<b>750mm Motor and Wiring Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>25311-06</td>
+							<td>Stepper Motor - NEMA 23</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>30679-05</td>
+							<td>Cable Assembly, Stepper Motor 73 in long (X-Axis)</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30679-06</td>
+							<td>Cable Assembly, Stepper Motor 34 in long (Y1-Axis)</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30679-07</td>
+							<td>Cable Assembly, Stepper Motor 71 in long (Y2-Axis)</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30679-08</td>
+							<td>Cable Assembly, Stepper Motor 73 in long (Z-Axis)</td>
+							<td>1</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="drag-chain-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#drag-chain-accordion" href="#drag-chain" aria-expanded="false" aria-controls="drag-chain" style="color:#fff;background:#8A52A1" class="panel-heading" role="tab" id="drag-chain-header">
+				<h4 class="panel-title">
+					<strong>Drag Chain</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="drag-chain" class="panel-collapse collapse" role="tabpanel" aria-labelledby="drag-chain-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #8A52A1" colspan="3">
+								<b>750mm Drag Chain Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30527-05</td>
+							<td>Drag Chain Bracket</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30527-06</td>
+							<td>Drag Chain Bracket</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30680-01</td>
+							<td>Zip Tie Mount</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>26016-03</td>
+							<td>T-Nut M5 Post Assembly</td>
+							<td>5</td>
+						</tr>
+						<tr>
+							<td>30681-01</td>
+							<td>Drag Chain Support Arm</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30331-12</td>
+							<td>Drag Chain 18x25 16 Links w/ Custom Ends</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25986-03</td>
+							<td>Cable Tie 4" (100 Pack)</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>26049-08</td>
+							<td>Extrusion T-Slot 20x20 x 750mm Tapped</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25286-44</td>
+							<td>Button Head Cap Screw M4 x 10</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>25286-31</td>
+							<td>Button Head Cap Screw M5 x 6</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25286-46</td>
+							<td>Button Head Cap Screw M5 x 14</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30554-06</td>
+							<td>Flat Head Cap Screw M5 x 10</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>30554-07</td>
+							<td>Flat Head Cap Screw M5 x 12</td>
+							<td>6</td>
+						</tr>
+						<tr>
+							<td>30265-08</td>
+							<td>Hex Nut M4 Nylon Locking</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30265-10</td>
+							<td>Hex Nut M5 Nylon Locking</td>
+							<td>6</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="home-switch-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#home-switch-accordion" href="#home-switch" aria-expanded="false" aria-controls="home-switch" style="color:#fff;background:#F47B44" class="panel-heading" role="tab" id="home-switch-header">
+				<h4 class="panel-title">
+					<strong>Home Switch</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="home-switch" class="panel-collapse collapse" role="tabpanel" aria-labelledby="home-switch-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #F47B44" colspan="3">
+								<b>750mm Homing Switch Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30557-02</td>
+							<td>Microswitch</td>
+							<td>3</td>
+						</tr>
+						<tr>
+							<td>26016-03</td>
+							<td>Post-Assembly M5 T-Slot Nuts</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30682-04</td>
+							<td>Cable Assembly, 2C Lugs Ferrules 76"Lg X-Limit</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30682-05</td>
+							<td>Cable Assembly, 2C Lugs Ferrules 39"Lg Y-Limit</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30682-06</td>
+							<td>Cable Assembly, 2C Lugs Ferrules 76"Lg Z-Limit</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25312-25</td>
+							<td>Spacer 5.1mm ID 9.5mm 10.5mm Lg Aluminum</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25284-12</td>
+							<td>Hex Nut M2x0.4</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30265-07</td>
+							<td>Hex Nut M3 Nylon Locking</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-56</td>
+							<td>Socket Head Screw M2 x 10</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25285-57</td>
+							<td>Socket Head Screw M2 x 14</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>25285-44</td>
+							<td>Socket Head Screw M3 x 20</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-51</td>
+							<td>Socket Head Screw M5 x 16</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30555-03</td>
+							<td>Washer, Split Lock M2 Stainless</td>
+							<td>6</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="waste-board-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#waste-board-accordion" href="#waste-board" aria-expanded="false" aria-controls="waste-board" style="color:#fff;background:#0a91d1" class="panel-heading" role="tab" id="waste-board-header">
+				<h4 class="panel-title">
+					<strong>Waste Board</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="waste-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="waste-board-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #0a91d1" colspan="3">
+								<b>750mm Waste Board Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>25281-10</td>
+							<td>T-Slot Nut M5 Pre-Assembly</td>
+							<td>12</td>
+						</tr>
+						<tr>
+							<td>30517-08</td>
+							<td>Threaded Insert M5 x 10</td>
+							<td>64</td>
+						</tr>
+						<tr>
+							<td>30683-01</td>
+							<td>750mm Waste Board</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25286-40</td>
+							<td>Button Head Cap Screw M5 x 12</td>
+							<td>12</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="side-board-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#side-board-accordion" href="#side-board" aria-expanded="false" aria-controls="side-board" style="color:#fff;background:#9D9FA2" class="panel-heading" role="tab" id="side-board-header">
+				<h4 class="panel-title">
+					<strong>Side Board</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="side-board" class="panel-collapse collapse" role="tabpanel" aria-labelledby="side-board-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #9D9FA2" colspan="3">
+								<b>750mm Side Board Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30684-01</td>
+							<td>Extrusion Connection Bracket</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25281-13</td>
+							<td>T-Slot Nut M5 Pre-Assembly</td>
+							<td>21</td>
+						</tr>
+						<tr>
+							<td>26018-01</td>
+							<td>Cast Corner Bracket, Clear</td>
+							<td>4</td>
+						</tr>
+						<tr>
+							<td>30517-11</td>
+							<td>Threaded Insert M5</td>
+							<td>12</td>
+						</tr>
+						<tr>
+							<td>30685-02</td>
+							<td>Side Board, X-Carve 750mm Size</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>26049-10</td>
+							<td>Extrusion T-Slot 20x20 x 250mm</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>26049-05</td>
+							<td>Extrusion T-Slot 20x20 x 708mm</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25286-34</td>
+							<td>Button Head Cap Screw M5 x 8</td>
+							<td>8</td>
+						</tr>
+						<tr>
+							<td>25286-37</td>
+							<td>Button Head Cap Screw M5 x 10</td>
+							<td>8</td>
+						</tr>
+						<tr>
+							<td>25286-41</td>
+							<td>Button Head Cap Screw M5 x 12</td>
+							<td>5</td>
+						</tr>
+						<tr>
+							<td>25286-47</td>
+							<td>Button Head Cap Screw M5 x 14</td>
+							<td>12</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="spindle-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#spindle-accordion" href="#spindle" aria-expanded="false" aria-controls="spindle" style="color:#fff;background:#42a44e" class="panel-heading" role="tab" id="spindle-header">
+				<h4 class="panel-title">
+					<strong>Spindle</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="spindle" class="panel-collapse collapse" role="tabpanel" aria-labelledby="spindle-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #42a44e" colspan="3">
+								<b>110V DeWalt 611 Spindle and Mount</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30621-01</td>
+							<td>DeWalt 611 Router</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30610-01</td>
+							<td>X-Carve DeWalt 611 Spindle Mount</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-55</td>
+							<td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+							<td>3</td>
+						</tr>
+						<tr>
+							<td>25286-45</td>
+							<td>Button Head Cap Screw M5 × 16mm</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30558-01</td>
+							<td>Inventables Label</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30662-01</td>
+							<td>1/4" to 1/8" Collet Adapter</td>
+							<td>1</td>
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td style="color:#fff;background: #42a44e" colspan="3">
+								<b>240V DeWalt 611 Spindle and Mount</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30621-02</td>
+							<td>240V DeWalt 26200 router</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30610-01</td>
+							<td>X-Carve DeWalt 611 Spindle Mount</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-55</td>
+							<td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+							<td>3</td>
+						</tr>
+						<tr>
+							<td>25286-45</td>
+							<td>Button Head Cap Screw M5 × 16mm</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30558-01</td>
+							<td>Inventables Label</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30662-01</td>
+							<td>1/4" to 1/8" Collet Adapter</td>
+							<td>1</td>
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td style="color:#fff;background: #42a44e" colspan="3">
+								<b>X-Carve DeWalt 611 Spindle Mount (Does Not Include Spindle)</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30610-01</td>
+							<td>X-Carve DeWalt 611 Spindle Mount</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-55</td>
+							<td>Socket Head Cap Screw M4 x 16mm Low Profile</td>
+							<td>3</td>
+						</tr>
+						<tr>
+							<td>30558-01</td>
+							<td>Inventables Label</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25286-45</td>
+							<td>Button Head Cap Screw M5 × 16mm</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>30662-01</td>
+							<td>1/4" to 1/8" Collet Adapter</td>
+							<td>1</td>
+						</tr>
+					</table>
+					<table>
+						<tr>
+							<td style="color:#fff;background: #42a44e" colspan="3">
+								<b>Bosch Colt Spindle Mount Kit</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30287-01</td>
+							<td>Spindle Mounting Plate</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30329-03</td>
+							<td>Bosch Colt Spindle Mount</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30549-01</td>
+							<td>Rubber Inventables Sticker</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25286-18</td>
+							<td>Button Head Cap Screw M5 x 10</td>
+							<td>2</td>
+						</tr>
+						<tr>
+							<td>25287-08</td>
+							<td>Flat Washer M5</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-37</td>
+							<td>Socket Head Screw M5 x 20</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>25285-38</td>
+							<td>Socket Head Screw M5 x 25</td>
+							<td>1</td>
+						</tr>
+						<tr>
+							<td>30555-01</td>
+							<td>Split Lockwashers M5</td>
+							<td>1</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="panel-group" id="z-probe-accordion" role="tablist" aria-multiselectable="true">
+		<div class="panel panel-default">
+			<div data-toggle="collapse" data-parent="#z-probe-accordion" href="#z-probe" aria-expanded="false" aria-controls="z-probe" style="color:#fff;background:#000" class="panel-heading" role="tab" id="z-probe-header">
+				<h4 class="panel-title">
+					<strong>Z-Probe</strong>
+				</h4>
+				<div class="expand-icons">
+					<i class="fa fa-plus"></i>
+					<i class="fa fa-minus"></i>
+				</div>
+			</div>
+			<div id="z-probe" class="panel-collapse collapse" role="tabpanel" aria-labelledby="z-probe-header">
+				<div class="panel-body">
+					<table>
+						<tr>
+							<td style="color:#fff;background: #000" colspan="3">
+								<b>Z-Probe</b>
+							</td>
+						</tr>
+						<tr>
+							<td>
+								<b>SKU</b>
+							</td>
+							<td>
+								<b>Name</b>
+							</td>
+							<td>
+								<b>Quantity</b>
+							</td>
+						</tr>
+						<tr>
+							<td>30611-02</td>
+							<td>Z-Probe Kit</td>
+							<td>1</td>
+						</tr>
+					</table>
+				</div>
+			</div>
+		</div>
+	</div>
 </div>

--- a/750mm/index.md
+++ b/750mm/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: 'Welcome!'
-step-number: 1
+step_number: 1
 permalink: /750mm/
 next-step: /750mm/step1/
 next-step-title: 'Work Area'

--- a/750mm/step1/index.md
+++ b/750mm/step1/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: "Work Area"
 step_number: 1
 permalink: /750mm/step1/
-next-step: /750mm/step2a/1sideplates/
-next-step-title: "Gantry"
+next_step: /750mm/step2a/1sideplates/
+next_step_title: "Gantry"
 ---
 
 <table>

--- a/750mm/step1/index.md
+++ b/750mm/step1/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Work Area"
-step-number: 1
+step_number: 1
 permalink: /750mm/step1/
 next-step: /750mm/step2a/1sideplates/
 next-step-title: "Gantry"

--- a/750mm/step10/index.md
+++ b/750mm/step10/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Computer Setup"
-step-number: 1
+step_number: 1
 permalink: /750mm/step10/
 ---
 

--- a/750mm/step2a/1sideplates/index.md
+++ b/750mm/step2a/1sideplates/index.md
@@ -4,8 +4,8 @@ title: "Gantry Side Plates"
 parent: "Side Plates"
 step_number: 2
 permalink: /750mm/step2a/1sideplates/
-next-step: /750mm/step2a/2fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /750mm/step2a/2fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 ---
 
 <img src="../../step2/photo/jpfs_DSC2610.jpg">

--- a/750mm/step2a/1sideplates/index.md
+++ b/750mm/step2a/1sideplates/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Gantry Side Plates"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/1sideplates/
 next-step: /750mm/step2a/2fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/750mm/step2a/2fixedvwheels/index.md
+++ b/750mm/step2a/2fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: Side Plates
 step_number: 2
 permalink: /750mm/step2a/2fixedvwheels/
-next-step: /750mm/step2a/3adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /750mm/step2a/3adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "fixedvwheels1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2564.jpg">

--- a/750mm/step2a/2fixedvwheels/index.md
+++ b/750mm/step2a/2fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Fixed V-Wheels"
 parent: Side Plates
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/2fixedvwheels/
 next-step: /750mm/step2a/3adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/750mm/step2a/3adjustablevwheels/index.md
+++ b/750mm/step2a/3adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Adjustable V-Wheels"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/3adjustablevwheels/
 next-step: /750mm/step2a/4idlers/
 next-step-title: "Idler Wheels"

--- a/750mm/step2a/3adjustablevwheels/index.md
+++ b/750mm/step2a/3adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: "Side Plates"
 step_number: 2
 permalink: /750mm/step2a/3adjustablevwheels/
-next-step: /750mm/step2a/4idlers/
-next-step-title: "Idler Wheels"
+next_step: /750mm/step2a/4idlers/
+next_step_title: "Idler Wheels"
 diagram: "adjustablevwheels1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2591.jpg">

--- a/750mm/step2a/4idlers/index.md
+++ b/750mm/step2a/4idlers/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Idler Wheels"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/4idlers/
 next-step: /750mm/step2a/5motors/
 next-step-title: "Stepper Motors"

--- a/750mm/step2a/4idlers/index.md
+++ b/750mm/step2a/4idlers/index.md
@@ -4,8 +4,8 @@ title: "Attach Idler Wheels"
 parent: "Side Plates"
 step_number: 2
 permalink: /750mm/step2a/4idlers/
-next-step: /750mm/step2a/5motors/
-next-step-title: "Stepper Motors"
+next_step: /750mm/step2a/5motors/
+next_step_title: "Stepper Motors"
 diagram: "idlers1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2597.jpg">

--- a/750mm/step2a/5motors/index.md
+++ b/750mm/step2a/5motors/index.md
@@ -4,8 +4,8 @@ title: "Attach Stepper Motors"
 parent: "Side Plates"
 step_number: 2
 permalink: /750mm/step2a/5motors/
-next-step: /750mm/step2a/6dragchain/
-next-step-title: "Drag Chain"
+next_step: /750mm/step2a/6dragchain/
+next_step_title: "Drag Chain"
 diagram: "motors1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2606.jpg">

--- a/750mm/step2a/5motors/index.md
+++ b/750mm/step2a/5motors/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Stepper Motors"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/5motors/
 next-step: /750mm/step2a/6dragchain/
 next-step-title: "Drag Chain"

--- a/750mm/step2a/6dragchain/index.md
+++ b/750mm/step2a/6dragchain/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Bracket"
 parent: "Side Plates"
 step_number: 2
 permalink: /750mm/step2a/6dragchain/
-next-step: /750mm/step2a/7homeswitch/
-next-step-title: "Homing Switches"
+next_step: /750mm/step2a/7homeswitch/
+next_step_title: "Homing Switches"
 diagram: "dragchain1.jpg"
 ---
 <img src="jpfsimage4.jpg">

--- a/750mm/step2a/6dragchain/index.md
+++ b/750mm/step2a/6dragchain/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Drag Chain Bracket"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/6dragchain/
 next-step: /750mm/step2a/7homeswitch/
 next-step-title: "Homing Switches"

--- a/750mm/step2a/7homeswitch/index.md
+++ b/750mm/step2a/7homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Homing Switches"
 parent: "Side Plates"
 step_number: 2
 permalink: /750mm/step2a/7homeswitch/
-next-step: /750mm/step2b/1xcarriage/
-next-step-title: "X-Carriage"
+next_step: /750mm/step2b/1xcarriage/
+next_step_title: "X-Carriage"
 diagram: "homeswitch1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2616.jpg">

--- a/750mm/step2a/7homeswitch/index.md
+++ b/750mm/step2a/7homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Homing Switches"
 parent: "Side Plates"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2a/7homeswitch/
 next-step: /750mm/step2b/1xcarriage/
 next-step-title: "X-Carriage"

--- a/750mm/step2b/1xcarriage/index.md
+++ b/750mm/step2b/1xcarriage/index.md
@@ -4,8 +4,8 @@ title: "Assemble X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/1xcarriage/
-next-step: /750mm/step2b/2idlers/
-next-step-title: "Idler Wheels"
+next_step: /750mm/step2b/2idlers/
+next_step_title: "Idler Wheels"
 ---
 
 In this section we'll be assembling The X-Carriage. This carriage carries the hardware for moving the X axis as well as the Z axis, though we'll be assembling the latter component in the next section

--- a/750mm/step2b/1xcarriage/index.md
+++ b/750mm/step2b/1xcarriage/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Assemble X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/1xcarriage/
 next-step: /750mm/step2b/2idlers/
 next-step-title: "Idler Wheels"

--- a/750mm/step2b/2idlers/index.md
+++ b/750mm/step2b/2idlers/index.md
@@ -4,8 +4,8 @@ title: "Attach Smooth Idlers"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/2idlers/
-next-step: /750mm/step2b/3fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /750mm/step2b/3fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 diagram: "idlers.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150151.jpg">

--- a/750mm/step2b/2idlers/index.md
+++ b/750mm/step2b/2idlers/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Smooth Idlers"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/2idlers/
 next-step: /750mm/step2b/3fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/750mm/step2b/3fixedvwheels/index.md
+++ b/750mm/step2b/3fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Fixed V-Wheels"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/3fixedvwheels/
 next-step: /750mm/step2b/4adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/750mm/step2b/3fixedvwheels/index.md
+++ b/750mm/step2b/3fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/3fixedvwheels/
-next-step: /750mm/step2b/4adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /750mm/step2b/4adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "fixedvwheels.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2641.jpg">

--- a/750mm/step2b/4adjustablevwheels/index.md
+++ b/750mm/step2b/4adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Adjustable V-Wheels"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/4adjustablevwheels/
 next-step: /750mm/step2b/5motors/
 next-step-title: "Stepper Motors"

--- a/750mm/step2b/4adjustablevwheels/index.md
+++ b/750mm/step2b/4adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/4adjustablevwheels/
-next-step: /750mm/step2b/5motors/
-next-step-title: "Stepper Motors"
+next_step: /750mm/step2b/5motors/
+next_step_title: "Stepper Motors"
 diagram: "adjustablevwheels.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2648.jpg">

--- a/750mm/step2b/5motors/index.md
+++ b/750mm/step2b/5motors/index.md
@@ -4,8 +4,8 @@ title: "Attach Stepper Motor to X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/5motors/
-next-step: /750mm/step2b/6dragchain/
-next-step-title: "Drag Chain Bracket"
+next_step: /750mm/step2b/6dragchain/
+next_step_title: "Drag Chain Bracket"
 diagram: "motors.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2652.jpg">

--- a/750mm/step2b/5motors/index.md
+++ b/750mm/step2b/5motors/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Stepper Motor to X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/5motors/
 next-step: /750mm/step2b/6dragchain/
 next-step-title: "Drag Chain Bracket"

--- a/750mm/step2b/6dragchain/index.md
+++ b/750mm/step2b/6dragchain/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Bracket To X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/6dragchain/
-next-step: /750mm/step2b/7homeswitch/
-next-step-title: "Homing Switch"
+next_step: /750mm/step2b/7homeswitch/
+next_step_title: "Homing Switch"
 diagram: "dragchain.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150160.jpg">

--- a/750mm/step2b/6dragchain/index.md
+++ b/750mm/step2b/6dragchain/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Drag Chain Bracket To X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/6dragchain/
 next-step: /750mm/step2b/7homeswitch/
 next-step-title: "Homing Switch"

--- a/750mm/step2b/7homeswitch/index.md
+++ b/750mm/step2b/7homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Home Switch to X-Carriage"
 parent: X-Carriage
-step-number: 2
+step_number: 2
 permalink: /750mm/step2b/7homeswitch/
 next-step: /750mm/step2c/1zaxis/
 next-step-title: "Z-Axis"

--- a/750mm/step2b/7homeswitch/index.md
+++ b/750mm/step2b/7homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Home Switch to X-Carriage"
 parent: X-Carriage
 step_number: 2
 permalink: /750mm/step2b/7homeswitch/
-next-step: /750mm/step2c/1zaxis/
-next-step-title: "Z-Axis"
+next_step: /750mm/step2c/1zaxis/
+next_step_title: "Z-Axis"
 diagram: "homeswitch.jpg"
 ---
 <img src="../../step2/photo/jpfsP7150166.jpg">

--- a/750mm/step2c/01zaxis/index.md
+++ b/750mm/step2c/01zaxis/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Z-Axis"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/1zaxis/
 next-step: /750mm/step2c/2flangedbearing/
 next-step-title: "Flanged Bearing"

--- a/750mm/step2c/01zaxis/index.md
+++ b/750mm/step2c/01zaxis/index.md
@@ -4,8 +4,8 @@ title: "Z-Axis"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/1zaxis/
-next-step: /750mm/step2c/2flangedbearing/
-next-step-title: "Flanged Bearing"
+next_step: /750mm/step2c/2flangedbearing/
+next_step_title: "Flanged Bearing"
 ---
 
 In this section we'll assemble the Z-Axis rail, leadscrew, and spindle mount. This assembly will be attached to the X-Carriage.

--- a/750mm/step2c/02flangedbearing/index.md
+++ b/750mm/step2c/02flangedbearing/index.md
@@ -4,8 +4,8 @@ title: "Attach Flanged Bearing to Z-Axis Plate"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/2flangedbearing/
-next-step: /750mm/step2c/3attachrail/
-next-step-title: "Z-Axis Rail"
+next_step: /750mm/step2c/3attachrail/
+next_step_title: "Z-Axis Rail"
 diagram: "../02flangedbearing/flangedbearing.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2684.jpg">

--- a/750mm/step2c/02flangedbearing/index.md
+++ b/750mm/step2c/02flangedbearing/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Flanged Bearing to Z-Axis Plate"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/2flangedbearing/
 next-step: /750mm/step2c/3attachrail/
 next-step-title: "Z-Axis Rail"

--- a/750mm/step2c/03attachrail/index.md
+++ b/750mm/step2c/03attachrail/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Rail"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/3attachrail/
-next-step: /750mm/step2c/4leadscrew/
-next-step-title: "Leadscrew"
+next_step: /750mm/step2c/4leadscrew/
+next_step_title: "Leadscrew"
 diagram: "../03attachrail/attachrail.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2687.jpg">

--- a/750mm/step2c/03attachrail/index.md
+++ b/750mm/step2c/03attachrail/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Z-Axis Rail"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/3attachrail/
 next-step: /750mm/step2c/4leadscrew/
 next-step-title: "Leadscrew"

--- a/750mm/step2c/04leadscrew/index.md
+++ b/750mm/step2c/04leadscrew/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Install Leadscrew"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/4leadscrew/
 next-step: /750mm/step2c/5attachtocarriage/
 next-step-title: "Attach Z-Axis"

--- a/750mm/step2c/04leadscrew/index.md
+++ b/750mm/step2c/04leadscrew/index.md
@@ -4,8 +4,8 @@ title: "Install Leadscrew"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/4leadscrew/
-next-step: /750mm/step2c/5attachtocarriage/
-next-step-title: "Attach Z-Axis"
+next_step: /750mm/step2c/5attachtocarriage/
+next_step_title: "Attach Z-Axis"
 diagram: "../04leadscrew/leadscrew.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2705.jpg">

--- a/750mm/step2c/05attachtocarriage/index.md
+++ b/750mm/step2c/05attachtocarriage/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Assembly to X-Carriage"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/5attachtocarriage/
-next-step: /750mm/step2c/6adjustablevwheels/
-next-step-title: "Adjustable V-Wheels"
+next_step: /750mm/step2c/6adjustablevwheels/
+next_step_title: "Adjustable V-Wheels"
 diagram: "../05attachtocarriage/attachtocarriage1.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2723.jpg">

--- a/750mm/step2c/05attachtocarriage/index.md
+++ b/750mm/step2c/05attachtocarriage/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Z-Axis Assembly to X-Carriage"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/5attachtocarriage/
 next-step: /750mm/step2c/6adjustablevwheels/
 next-step-title: "Adjustable V-Wheels"

--- a/750mm/step2c/06adjustablevwheels/index.md
+++ b/750mm/step2c/06adjustablevwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Adjustable V-Wheels"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/6adjustablevwheels/
-next-step: /750mm/step2c/7fixedvwheels/
-next-step-title: "Fixed V-Wheels"
+next_step: /750mm/step2c/7fixedvwheels/
+next_step_title: "Fixed V-Wheels"
 diagram: "../06adjustablevwheels/adjustablevwheels3.jpg"
 ---
 

--- a/750mm/step2c/06adjustablevwheels/index.md
+++ b/750mm/step2c/06adjustablevwheels/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Adjustable V-Wheels"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/6adjustablevwheels/
 next-step: /750mm/step2c/7fixedvwheels/
 next-step-title: "Fixed V-Wheels"

--- a/750mm/step2c/07fixedvwheels/index.md
+++ b/750mm/step2c/07fixedvwheels/index.md
@@ -4,8 +4,8 @@ title: "Attach Fixed V-Wheels"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/7fixedvwheels/
-next-step: /750mm/step2c/8clampbolts/
-next-step-title: "Clamp Bolts"
+next_step: /750mm/step2c/8clampbolts/
+next_step_title: "Clamp Bolts"
 diagram: "../07fixedvwheels/fixedvwheels3.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2749.jpg">

--- a/750mm/step2c/07fixedvwheels/index.md
+++ b/750mm/step2c/07fixedvwheels/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Fixed V-Wheels"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/7fixedvwheels/
 next-step: /750mm/step2c/8clampbolts/
 next-step-title: "Clamp Bolts"

--- a/750mm/step2c/08clampbolts/index.md
+++ b/750mm/step2c/08clampbolts/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Insert Spindle Carriage Clamping Bolts"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/8clampbolts/
 next-step: /750mm/step2c/9attachmount/
 next-step-title: "Attach Spindle Mount"

--- a/750mm/step2c/08clampbolts/index.md
+++ b/750mm/step2c/08clampbolts/index.md
@@ -4,8 +4,8 @@ title: "Insert Spindle Carriage Clamping Bolts"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/8clampbolts/
-next-step: /750mm/step2c/9attachmount/
-next-step-title: "Attach Spindle Mount"
+next_step: /750mm/step2c/9attachmount/
+next_step_title: "Attach Spindle Mount"
 diagram: "../08clampbolts/clampbolts.jpg"
 ---
 <img src="../../step2/photo/jpfs_DSC2750.jpg">

--- a/750mm/step2c/09attachmount/index.md
+++ b/750mm/step2c/09attachmount/index.md
@@ -4,8 +4,8 @@ title: "Attach Spindle Carriage to Z-Axis"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/9attachmount/
-next-step: /750mm/step2c/10homeswitch/
-next-step-title: "Z-Axis Homing Switch"
+next_step: /750mm/step2c/10homeswitch/
+next_step_title: "Z-Axis Homing Switch"
 diagram: "../09attachmount/attachmount1.jpg"
 diagram2: "../09attachmount/attachmount2.jpg"
 ---

--- a/750mm/step2c/09attachmount/index.md
+++ b/750mm/step2c/09attachmount/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Spindle Carriage to Z-Axis"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/9attachmount/
 next-step: /750mm/step2c/10homeswitch/
 next-step-title: "Z-Axis Homing Switch"

--- a/750mm/step2c/10homeswitch/index.md
+++ b/750mm/step2c/10homeswitch/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Z-Axis Home Switch"
 parent: Z-Axis
-step-number: 2
+step_number: 2
 permalink: /750mm/step2c/10homeswitch/
 next-step: /750mm/step2d/1gantryrail/
 next-step-title: "Assemble Gantry"

--- a/750mm/step2c/10homeswitch/index.md
+++ b/750mm/step2c/10homeswitch/index.md
@@ -4,8 +4,8 @@ title: "Attach Z-Axis Home Switch"
 parent: Z-Axis
 step_number: 2
 permalink: /750mm/step2c/10homeswitch/
-next-step: /750mm/step2d/1gantryrail/
-next-step-title: "Assemble Gantry"
+next_step: /750mm/step2d/1gantryrail/
+next_step_title: "Assemble Gantry"
 ---
 
 <table>

--- a/750mm/step2d/1gantryrail/index.md
+++ b/750mm/step2d/1gantryrail/index.md
@@ -4,8 +4,8 @@ title: "Gantry"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /750mm/step2d/1gantryrail/
-next-step: /750mm/step2d/2attachsideplate/
-next-step-title: "Attach First Plate"
+next_step: /750mm/step2d/2attachsideplate/
+next_step_title: "Attach First Plate"
 ---
 We will now assemble the main gantry of the machine using the sub-assemblies you've built thus far. After this is assembled, your machine's frame will almost be complete.
 

--- a/750mm/step2d/1gantryrail/index.md
+++ b/750mm/step2d/1gantryrail/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Gantry"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2d/1gantryrail/
 next-step: /750mm/step2d/2attachsideplate/
 next-step-title: "Attach First Plate"

--- a/750mm/step2d/2attachsideplate/index.md
+++ b/750mm/step2d/2attachsideplate/index.md
@@ -4,8 +4,8 @@ title: "Attach Side Plate"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /750mm/step2d/2attachsideplate/
-next-step: /750mm/step2d/3attachcarriage/
-next-step-title: "Attach Carriage"
+next_step: /750mm/step2d/3attachcarriage/
+next_step_title: "Attach Carriage"
 ---
 
 <table>

--- a/750mm/step2d/2attachsideplate/index.md
+++ b/750mm/step2d/2attachsideplate/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Side Plate"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2d/2attachsideplate/
 next-step: /750mm/step2d/3attachcarriage/
 next-step-title: "Attach Carriage"

--- a/750mm/step2d/3attachcarriage/index.md
+++ b/750mm/step2d/3attachcarriage/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach X-Carriage Assembly"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2d/3attachcarriage/
 next-step: /750mm/step2d/4attachsideplate/
 next-step-title: "Side Plate"

--- a/750mm/step2d/3attachcarriage/index.md
+++ b/750mm/step2d/3attachcarriage/index.md
@@ -4,8 +4,8 @@ title: "Attach X-Carriage Assembly"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /750mm/step2d/3attachcarriage/
-next-step: /750mm/step2d/4attachsideplate/
-next-step-title: "Side Plate"
+next_step: /750mm/step2d/4attachsideplate/
+next_step_title: "Side Plate"
 ---
 
 

--- a/750mm/step2d/4attachsideplate/index.md
+++ b/750mm/step2d/4attachsideplate/index.md
@@ -4,8 +4,8 @@ title: "Gantry"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /750mm/step2d/4attachsideplate/
-next-step: /750mm/step2d/5dragchainrail/
-next-step-title: "Drag Chain Rail"
+next_step: /750mm/step2d/5dragchainrail/
+next_step_title: "Drag Chain Rail"
 ---
 
 <table>

--- a/750mm/step2d/4attachsideplate/index.md
+++ b/750mm/step2d/4attachsideplate/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Gantry"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2d/4attachsideplate/
 next-step: /750mm/step2d/5dragchainrail/
 next-step-title: "Drag Chain Rail"

--- a/750mm/step2d/5dragchainrail/index.md
+++ b/750mm/step2d/5dragchainrail/index.md
@@ -4,8 +4,8 @@ title: "Attach Drag Chain Rail"
 parent: "Assemble Gantry"
 step_number: 2
 permalink: /750mm/step2d/5dragchainrail/
-next-step: /750mm/step3/
-next-step-title: "Rails"
+next_step: /750mm/step3/
+next_step_title: "Rails"
 ---
 
 <table>

--- a/750mm/step2d/5dragchainrail/index.md
+++ b/750mm/step2d/5dragchainrail/index.md
@@ -2,7 +2,7 @@
 layout: default750mm
 title: "Attach Drag Chain Rail"
 parent: "Assemble Gantry"
-step-number: 2
+step_number: 2
 permalink: /750mm/step2d/5dragchainrail/
 next-step: /750mm/step3/
 next-step-title: "Rails"

--- a/750mm/step3/index.md
+++ b/750mm/step3/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: "Rails"
 step_number: 1
 permalink: /750mm/step3/
-next-step: /750mm/step4/
-next-step-title: "Belting"
+next_step: /750mm/step4/
+next_step_title: "Belting"
 ---
 In this step, you'll be assembling the main y axis rails and attaching them to the gantry. You'll then attach this assembly to the work area.
 

--- a/750mm/step3/index.md
+++ b/750mm/step3/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Rails"
-step-number: 1
+step_number: 1
 permalink: /750mm/step3/
 next-step: /750mm/step4/
 next-step-title: "Belting"

--- a/750mm/step4/index.md
+++ b/750mm/step4/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: "Belting"
 step_number: 1
 permalink: /750mm/step4/
-next-step: /750mm/step5/
-next-step-title: "Spindle"
+next_step: /750mm/step5/
+next_step_title: "Spindle"
 ---
 <p>This section covers installing the belting.</p>
 

--- a/750mm/step4/index.md
+++ b/750mm/step4/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Belting"
-step-number: 1
+step_number: 1
 permalink: /750mm/step4/
 next-step: /750mm/step5/
 next-step-title: "Spindle"

--- a/750mm/step5/index.md
+++ b/750mm/step5/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: "Spindle"
 step_number: 1
 permalink: /750mm/step5/
-next-step: /750mm/step6/
-next-step-title: "Wiring"
+next_step: /750mm/step6/
+next_step_title: "Wiring"
 ---
 In this step you'll be mounting a DeWalt 611 router in the spindle mount. Begin by removing existing base and collar from the spindle. This will leave just the metal router body.
 <img src="photo/jpfs_DSC2846.jpg">

--- a/750mm/step5/index.md
+++ b/750mm/step5/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Spindle"
-step-number: 1
+step_number: 1
 permalink: /750mm/step5/
 next-step: /750mm/step6/
 next-step-title: "Wiring"

--- a/750mm/step6/index.md
+++ b/750mm/step6/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: "Wiring"
 step_number: 6
 permalink: /750mm/step6/
-next-step: /750mm/step7/
-next-step-title: "Side Board"
+next_step: /750mm/step7/
+next_step_title: "Side Board"
 diagram: "wiringDiagram750.jpg"
 ---
 <table>

--- a/750mm/step6/index.md
+++ b/750mm/step6/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Wiring"
-step-number: 6
+step_number: 6
 permalink: /750mm/step6/
 next-step: /750mm/step7/
 next-step-title: "Side Board"

--- a/750mm/step7/index.md
+++ b/750mm/step7/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title: "Side Board"
-step-number: 1
+step_number: 1
 permalink: /750mm/step7/
 next-step: /750mm/step8/
 next-step-title: "X-Controller"

--- a/750mm/step7/index.md
+++ b/750mm/step7/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title: "Side Board"
 step_number: 1
 permalink: /750mm/step7/
-next-step: /750mm/step8/
-next-step-title: "X-Controller"
+next_step: /750mm/step8/
+next_step_title: "X-Controller"
 ---
 <table>
   <tr>

--- a/750mm/step8/index.md
+++ b/750mm/step8/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title:  "X-Controller"
-step-number: 1
+step_number: 1
 permalink: /750mm/step8/
 next-step: /750mm/step9/
 next-step-title: "Calibrate"

--- a/750mm/step8/index.md
+++ b/750mm/step8/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title:  "X-Controller"
 step_number: 1
 permalink: /750mm/step8/
-next-step: /750mm/step9/
-next-step-title: "Calibrate"
+next_step: /750mm/step9/
+next_step_title: "Calibrate"
 ---
 
 <img src="PB231421BATCH201.jpg">

--- a/750mm/step9/index.md
+++ b/750mm/step9/index.md
@@ -3,8 +3,8 @@ layout: default750mm
 title:  "Calibrate"
 step_number: 1
 permalink: /750mm/step9/
-next-step: /750mm/step10/
-next-step-title: "Computer Setup"
+next_step: /750mm/step10/
+next_step_title: "Computer Setup"
 ---
 
 

--- a/750mm/step9/index.md
+++ b/750mm/step9/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default750mm
 title:  "Calibrate"
-step-number: 1
+step_number: 1
 permalink: /750mm/step9/
 next-step: /750mm/step10/
 next-step-title: "Computer Setup"

--- a/_data/navigation2015.yml
+++ b/_data/navigation2015.yml
@@ -1,188 +1,187 @@
 stepnav:
-
-# List of steps
-- title: Let's Get Started!
-  url: /
-- title: X Carriage
-  url: /step02/
-  subnav:
-  - title: Smooth Idlers
-    url: '#smooth-idlers'
-  - title: V-Wheels
-    url: '#v-wheels'
-  - title: Positioning of Eccentric Nuts
-    url: '#eccentric-nuts'
-  - title: Motor Mounting
-    url: '#motor-mounting'
-  - title: Mounting Drag Chain End
-    url: '#drag-chain-end'
-  - title: Mounting Terminal Block
-    url: '#terminal-block'
-  - title: Mounting X-Axis Limit Switch
-    url: '#x-axis-limit-switch'
-- title: Y-Plates
-  url: /step03/
-  subnav:
-  - title: Smooth Idlers
-    url: '#smooth-idlers'
-  - title: V-Wheels
-    url: '#v-wheels'
-  - title: Y-Axis Motor Mounting
-    url: '#motor-mounting'
-  - title: Mounting Drag Chain End
-    url: '#drag-chain-end'
-  - title: Mounting Terminal Block
-    url: '#terminal-block'
-  - title: Mounting Y-Axis Limit Switch
-    url: '#mount-limit-switch'
-- title: Gantry
-  url: /step04/
-  subnav:
-  - title: Attach the Makerslide
-    url: '#attach-makerslide'
-  - title: Second piece of Makerslide
-    url: '#second-makerslide'
-  - title: Slide on X-Carriage
-    url: '#slide-on-x-carriage'
-  - title: Add Insertion Nuts
-    url: '#insertion-nuts'
-  - title: Attach Left Y-Plate
-    url: '#makerslide-left-y-plate'
-- title: Y-Axis
-  url: /step05/
-  subnav:
-  - title: Attach End Plates to Makerslide
-    url: '#attach-end-plates'
-  - title: Slide on Gantry
-    url: '#slide-on-gantry'
-  - title: Add Insertion Nuts
-    url: '#add-insertion-nuts'
-  - title: Attach Front End Plates
-    url: '#attach-front-end-plates'
-  - title: Connect End Plates
-    url: '#connect-end-plates'
-- title: Belting
-  url: /step06/
-  subnav:
-  - title: Align X-Axis Motor Pulley
-    url: '#align-x-axis-motor-pulley'
-  - title: Thread Belt Through
-    url: '#thread-belt-through'
-  - title: Repeat for Y-Axis
-    url: '#repeat'
-- title: Z-Axis
-  url: /step07/
-  subnav:
-  - title: Insert Flanged Bearing
-    url: '#insert-flanged-bearing'
-  - title: Attach Z-Plate
-    url: '#attach-z-plate'
-  - title: Attach Z-Axis to X-Carriage
-    url: '#attach-z-axis'
-  - title: Mount Z-Axis Limit Switch
-    url: '#limit-switch'
-- title: Drive Rod
-  url: /step08/
-- title: Z-Axis Motor
-  url: /step09/
-- title: Wiring
-  url: /step10/
-  subnav:
-  - title: Prepare Stepper Motor Wires
-    url: '#prepare-stepper-motor-wires'
-  - title: Secure Wires in Terminal Blocks
-    url: '#secure-wires'
-  - title: Prepare Stepper Cable
-    url: '#prepare-stepper-cable'
-  - title: Secure Stepper Cable
-    url: '#secure-stepper-cable'
-  - title: Solder Limit Switches
-    url: '#solder-limit-switches'
-- title: Drag Chain
-  url: /step11/
-- title: Spindle Mount
-  url: /step12/
-- title: Work Area
-  url: /step13/
-- title: Electronics
-  url: /step14/
-  subnav:
-  - title: Attach Power Supply
-    url: '#attach-power-supply'
-  - title: Mount gShield Enclosure
-    url: '#mount-gshield-enclosure'
-  - title: Strip Stepper Cable
-    url: '#strip-stepper-cable'
-  - title: Determine the Axes
-    url: '#determine-axes'
-  - title: Solder Pins to gShield
-    url: '#solder-pins'
-  - title: Wire Stepper Cable
-    url: '#wire-stepper-cable'
-  - title: Mount the Arduino
-    url: '#mount-arduino'
-  - title: Mount the gShield
-    url: '#mount-gshield'
-  - title: Power gShield and 24V Fan
-    url: '#power-gshield'
-  - title: Power 24V Spindle
-    url: '#power-spindle'
-  - title: Install Enclosure Cover
-    url: '#install-enclosure-cover'
-  - title: Install 24V Fan
-    url: '#install-fan'
-  - title: Connect PWM Spindle Control
-    url: '#connect-pwm'
-  - title: Connect Limit Switches
-    url: '#connect-limit-switches'
-  - title: Plug in Assembly
-    url: '#plug-in-assembly'
-- title: Calibrate
-  url: /step15/
-- title: Drivers
-  url: /step16/
-- title: Machine Setup
-  url: /step17/
-- title: Get Carving!
-  url: /step18/
+  # List of steps
+  - title: Let's Get Started!
+    url: /
+  - title: X Carriage
+    url: /step02/
+    subnav:
+      - title: Smooth Idlers
+        url: "#smooth-idlers"
+      - title: V-Wheels
+        url: "#v-wheels"
+      - title: Positioning of Eccentric Nuts
+        url: "#eccentric-nuts"
+      - title: Motor Mounting
+        url: "#motor-mounting"
+      - title: Mounting Drag Chain End
+        url: "#drag-chain-end"
+      - title: Mounting Terminal Block
+        url: "#terminal-block"
+      - title: Mounting X-Axis Limit Switch
+        url: "#x-axis-limit-switch"
+  - title: Y-Plates
+    url: /step03/
+    subnav:
+      - title: Smooth Idlers
+        url: "#smooth-idlers"
+      - title: V-Wheels
+        url: "#v-wheels"
+      - title: Y-Axis Motor Mounting
+        url: "#motor-mounting"
+      - title: Mounting Drag Chain End
+        url: "#drag-chain-end"
+      - title: Mounting Terminal Block
+        url: "#terminal-block"
+      - title: Mounting Y-Axis Limit Switch
+        url: "#mount-limit-switch"
+  - title: Gantry
+    url: /step04/
+    subnav:
+      - title: Attach the Makerslide
+        url: "#attach-makerslide"
+      - title: Second piece of Makerslide
+        url: "#second-makerslide"
+      - title: Slide on X-Carriage
+        url: "#slide-on-x-carriage"
+      - title: Add Insertion Nuts
+        url: "#insertion-nuts"
+      - title: Attach Left Y-Plate
+        url: "#makerslide-left-y-plate"
+  - title: Y-Axis
+    url: /step05/
+    subnav:
+      - title: Attach End Plates to Makerslide
+        url: "#attach-end-plates"
+      - title: Slide on Gantry
+        url: "#slide-on-gantry"
+      - title: Add Insertion Nuts
+        url: "#add-insertion-nuts"
+      - title: Attach Front End Plates
+        url: "#attach-front-end-plates"
+      - title: Connect End Plates
+        url: "#connect-end-plates"
+  - title: Belting
+    url: /step06/
+    subnav:
+      - title: Align X-Axis Motor Pulley
+        url: "#align-x-axis-motor-pulley"
+      - title: Thread Belt Through
+        url: "#thread-belt-through"
+      - title: Repeat for Y-Axis
+        url: "#repeat"
+  - title: Z-Axis
+    url: /step07/
+    subnav:
+      - title: Insert Flanged Bearing
+        url: "#insert-flanged-bearing"
+      - title: Attach Z-Plate
+        url: "#attach-z-plate"
+      - title: Attach Z-Axis to X-Carriage
+        url: "#attach-z-axis"
+      - title: Mount Z-Axis Limit Switch
+        url: "#limit-switch"
+  - title: Drive Rod
+    url: /step08/
+  - title: Z-Axis Motor
+    url: /step09/
+  - title: Wiring
+    url: /step10/
+    subnav:
+      - title: Prepare Stepper Motor Wires
+        url: "#prepare-stepper-motor-wires"
+      - title: Secure Wires in Terminal Blocks
+        url: "#secure-wires"
+      - title: Prepare Stepper Cable
+        url: "#prepare-stepper-cable"
+      - title: Secure Stepper Cable
+        url: "#secure-stepper-cable"
+      - title: Solder Limit Switches
+        url: "#solder-limit-switches"
+  - title: Drag Chain
+    url: /step11/
+  - title: Spindle Mount
+    url: /step12/
+  - title: Work Area
+    url: /step13/
+  - title: Electronics
+    url: /step14/
+    subnav:
+      - title: Attach Power Supply
+        url: "#attach-power-supply"
+      - title: Mount gShield Enclosure
+        url: "#mount-gshield-enclosure"
+      - title: Strip Stepper Cable
+        url: "#strip-stepper-cable"
+      - title: Determine the Axes
+        url: "#determine-axes"
+      - title: Solder Pins to gShield
+        url: "#solder-pins"
+      - title: Wire Stepper Cable
+        url: "#wire-stepper-cable"
+      - title: Mount the Arduino
+        url: "#mount-arduino"
+      - title: Mount the gShield
+        url: "#mount-gshield"
+      - title: Power gShield and 24V Fan
+        url: "#power-gshield"
+      - title: Power 24V Spindle
+        url: "#power-spindle"
+      - title: Install Enclosure Cover
+        url: "#install-enclosure-cover"
+      - title: Install 24V Fan
+        url: "#install-fan"
+      - title: Connect PWM Spindle Control
+        url: "#connect-pwm"
+      - title: Connect Limit Switches
+        url: "#connect-limit-switches"
+      - title: Plug in Assembly
+        url: "#plug-in-assembly"
+  - title: Calibrate
+    url: /step15/
+  - title: Drivers
+    url: /step16/
+  - title: Machine Setup
+    url: /step17/
+  - title: Get Carving!
+    url: /step18/
 
 accessories:
   - title: E-Stop with Enclosure
     url: /accessories/e-stop-with-enclosure/
     subnav:
-    - title: Disassemble Button
-      url: '#disassemble-button'
-    - title: Attach Button
-      url: '#attach-button'
-    - title: Attach Cable Strain Relief
-      url: '#attach-cable-strain-relief'
-    - title: Wire It Up
-      url: '#wire-it-up'
-    - title: Close It Up
-      url: '#close-it-up'
+      - title: Disassemble Button
+        url: "#disassemble-button"
+      - title: Attach Button
+        url: "#attach-button"
+      - title: Attach Cable Strain Relief
+        url: "#attach-cable-strain-relief"
+      - title: Wire It Up
+        url: "#wire-it-up"
+      - title: Close It Up
+        url: "#close-it-up"
 
-x-controller:
+x_controller:
   - title: X-Controller
     url: /x-controller/
     subnav:
-    - title: Install Power Supply
-      url: '#install-power-supply'
-    - title: Install Controller Board
-      url: '#install-controller-board'
-    - title: Install Front Panel
-      url: '#install-front-panel'
-    - title: Install Back Panel
-      url: '#install-back-panel'
+      - title: Install Power Supply
+        url: "#install-power-supply"
+      - title: Install Controller Board
+        url: "#install-controller-board"
+      - title: Install Front Panel
+        url: "#install-front-panel"
+      - title: Install Back Panel
+        url: "#install-back-panel"
 
-x-controller-usage:
+x_controller_usage:
   - title: X-Controller Usage
     url: /x-controller/usage/
     subnav:
-    - title: Option 1 - No New Wires
-      url: '#option-1'
-    - title: Option 2 - New Wires
-      url: '#option-2'
-    - title: Usage
-      url: '#usage'
-    - title: Troubleshooting
-      url: '#troubleshooting'
+      - title: Option 1 - No New Wires
+        url: "#option-1"
+      - title: Option 2 - New Wires
+        url: "#option-2"
+      - title: Usage
+        url: "#usage"
+      - title: Troubleshooting
+        url: "#troubleshooting"

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,24 +1,39 @@
 <div class="inventables-navbar-container" id="inventables-nav-outer">
-    <div class="container">
-    <nav class="navbar navbar-default">
+  <div class="container">
+    <nav class="navbar navbar-expand-lg">
       <ul class="nav nav-pills pull-left top-nav">
-          <li>
-              <a href="https://www.inventables.com" data-auto-route="true">
-                  <img id="site-logo" class="logo-big" src="https://d2rhdy377k7eul.cloudfront.net/assets/homepage/logo-47acab06c6d358b48d648cf80e5369eb.png" alt="Inventables">
-              </a>
-          </li>
+        <li>
+          <a href="https://www.inventables.com" data-auto-route="true">
+            <img
+              id="site-logo"
+              class="logo-big"
+              src="https://d2rhdy377k7eul.cloudfront.net/assets/shared/rebranding-inventables-logo-3007d3ef0bd3650e6dd865dfc8c3d211.svg"
+              alt="Inventables"
+            />
+          </a>
+        </li>
       </ul>
-      <ul id="inventables-navbar" class="nav navbar-nav navbar-right nav-pills pull-right">
-      </ul>
-      <ul class="nav navbar-nav nav-pills pull-left" id="flagship-nav">
-        <li><a href="https://www.inventables.com/technologies/x-carve">X-Carve</a></li>
-        <li><a href="https://www.inventables.com/technologies/carvey">Carvey</a></li>
-        <li><a href="https://www.inventables.com/technologies/easel">Easel</a></li>
+      <ul class="nav navbar-nav nav-pills ml-auto" id="flagship-nav">
+        <li>
+          <a href="https://www.inventables.com/technologies/x-carve">X-Carve</a>
+        </li>
+        <li>
+          <a href="https://www.inventables.com/technologies/carvey">Carvey</a>
+        </li>
+        <li>
+          <a href="https://www.inventables.com/technologies/easel">Easel</a>
+        </li>
         <li><a href="https://www.inventables.com/projects">Projects</a></li>
         <li><a href="https://www.inventables.com/forum">Forum</a></li>
         <li><a href="https://inventables.desk.com">Support</a></li>
-        <li><a href="https://github.com/inventables/x-carve-instructions" class="github-link"><i class="fa fa-code-fork"></i>Contribute to these instructions!</a></li>
+        <li>
+          <a
+            href="https://github.com/inventables/x-carve-instructions"
+            class="github-link"
+            ><i class="fa fa-code-fork"></i>Contribute to these instructions!</a
+          >
+        </li>
       </ul>
     </nav>
-    </div>
+  </div>
 </div>

--- a/_includes/next-step.html
+++ b/_includes/next-step.html
@@ -1,3 +1,4 @@
-{% if page.next-step %}
-  <a href="{{ site.baseurl }}{{ page.next-step }}" class="btn-invent btn-animate-arrow btn-next">Next Step: {{ page.next-step-title }}</a>
+{% if page.next_step %}
+<a href="{{ site.baseurl }}{{ page.next_step }}" class="btn-invent btn-animate-arrow btn-next">Next Step: {{
+  page.next_step_title }}</a>
 {% endif %}

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,6 @@
 <script src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
-<script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>
+<script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"></script>
 <script src="{{ "/js/sticky.js"| prepend: site.baseurl }}"></script>
 <script src="{{ "/js/jquery.colorbox-min.js" | prepend: site.baseurl }}"></script>
 <script src="{{ "/js/lightbox.js"| prepend: site.baseurl }}"></script>
@@ -11,12 +12,12 @@
   var githubBaseUrl = 'inventables.github.io/x-carve-instructions'
     , inventablesBaseUrl = 'x-carve-instructions.inventables.com'
     , currentUrl = window.location.href;
-  
+
   if (currentUrl.indexOf(githubBaseUrl) !== -1) {
     window.location = currentUrl.replace(githubBaseUrl, inventablesBaseUrl).replace("https://", "http://");
   }
-  
-  $(function() {
+
+  $(function () {
     smoothScroll.init();
   });
 </script>

--- a/_includes/subnav.html
+++ b/_includes/subnav.html
@@ -1,63 +1,63 @@
 {% for item in site.data.navigation.stepnav %}
-  {% if page.url == item.url %}
-    {% if item.subnav %}
-      <div id="subnav">
-        <ol class="nav subnav">
-          <h4>Steps in this section:</h4>
-          {% for subitem in item.subnav %}
-            <li><a data-scroll href="{{ subitem.url }}">{{ subitem.title }}</a></li>
-          {% endfor %}
-            <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
-        </ol>
-      </div>
-    {% endif %}
-  {% endif %}
+{% if page.url == item.url %}
+{% if item.subnav %}
+<div id="subnav">
+  <ol class="nav subnav">
+    <h4>Steps in this section:</h4>
+    {% for subitem in item.subnav %}
+    <li><a data-scroll href="{{ subitem.url }}">{{ subitem.title }}</a></li>
+    {% endfor %}
+    <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
+  </ol>
+</div>
+{% endif %}
+{% endif %}
 {% endfor %}
 
 {% for item in site.data.navigation.accessories %}
-  {% if page.url == item.url %}
-    {% if item.subnav %}
-      <div id="subnav">
-        <ol class="nav subnav">
-          <h4>Steps in this section:</h4>
-          {% for subitem in item.subnav %}
-            <li><a data-scroll href="{{ subitem.url | prepend: site.baseurl }}">{{ subitem.title }}</a></li>
-          {% endfor %}
-            <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
-        </ol>
-      </div>
-    {% endif %}
-  {% endif %}
+{% if page.url == item.url %}
+{% if item.subnav %}
+<div id="subnav">
+  <ol class="nav subnav">
+    <h4>Steps in this section:</h4>
+    {% for subitem in item.subnav %}
+    <li><a data-scroll href="{{ subitem.url | prepend: site.baseurl }}">{{ subitem.title }}</a></li>
+    {% endfor %}
+    <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
+  </ol>
+</div>
+{% endif %}
+{% endif %}
 {% endfor %}
 
-{% for item in site.data.navigation.x-controller %}
-  {% if page.url == item.url %}
-    {% if item.subnav %}
-      <div id="subnav">
-        <ol class="nav subnav">
-          <h4>X-Controller Steps:</h4>
-          {% for subitem in item.subnav %}
-            <li><a data-scroll href="{{ subitem.url }}">{{ subitem.title }}</a></li>
-          {% endfor %}
-            <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
-        </ol>
-      </div>
-    {% endif %}
-  {% endif %}
+{% for item in site.data.navigation.x_controller %}
+{% if page.url == item.url %}
+{% if item.subnav %}
+<div id="subnav">
+  <ol class="nav subnav">
+    <h4>X-Controller Steps:</h4>
+    {% for subitem in item.subnav %}
+    <li><a data-scroll href="{{ subitem.url }}">{{ subitem.title }}</a></li>
+    {% endfor %}
+    <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
+  </ol>
+</div>
+{% endif %}
+{% endif %}
 {% endfor %}
 
-{% for item in site.data.navigation.x-controller-usage %}
-  {% if page.url == item.url %}
-    {% if item.subnav %}
-      <div id="subnav">
-        <ol class="nav subnav">
-          <h4>X-Controller Usage:</h4>
-          {% for subitem in item.subnav %}
-            <li><a data-scroll href="{{ subitem.url }}">{{ subitem.title }}</a></li>
-          {% endfor %}
-            <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
-        </ol>
-      </div>
-    {% endif %}
-  {% endif %}
+{% for item in site.data.navigation.x_controller_usage %}
+{% if page.url == item.url %}
+{% if item.subnav %}
+<div id="subnav">
+  <ol class="nav subnav">
+    <h4>X-Controller Usage:</h4>
+    {% for subitem in item.subnav %}
+    <li><a data-scroll href="{{ subitem.url }}">{{ subitem.title }}</a></li>
+    {% endfor %}
+    <li class="return-top"><a data-scroll href="#"><i class="fa fa-arrow-up"></i>Return to top</a></li>
+  </ol>
+</div>
+{% endif %}
+{% endif %}
 {% endfor %}

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
+
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
+
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -10,51 +12,55 @@
         {% include stepnav1000mm.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">{% include stepnav1000mm.html %}</div>
+      <div class="row topic-nav">
+          {% include stepnav1000mm.html %}
+      </div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
-              <a href="{{site.baseurl}}/1000mm/">1000mm</a> {% if page.parent %}
-              &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/1000mm/">1000mm</a>
+              {% if page.parent %}
+                &#47;
+                  {{ page.parent }}
+              {% endif %}
+              &#47;
               <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
+                {% if page.title %}
+                  {{ page.title }}
+                {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %} {% if page.grabcad-url1 %}
-            <a class="grabcad-link" href="{{page.grabcad-url1}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad-url2 %}
-            <a class="grabcad-link" href="{{page.grabcad-url2}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+            {% if page.time-estimate %}
+            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
             {% endif %}
+
+            {% if page.grabcad-url1 %}
+              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
+              {% if page.z-axis == true %}
+                <span class="grabcad-note">(You're only building part of this now)</span>
+              {% endif %}
+            {% endif %}
+            {% if page.grabcad-url2 %}
+              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
+            {% endif %}
+
           </header>
           <div class="step-text">
-            {{ content }} {% include next-step.html %}
+            {{ content }}
+            {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
+          {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          {% endif %}
+          {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          {% endif %}
           </div>
         </div>
       </div>

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
-
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
-
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -12,60 +10,55 @@
         {% include stepnav1000mm.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">
-          {% include stepnav1000mm.html %}
-      </div>
+      <div class="row topic-nav">{% include stepnav1000mm.html %}</div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/1000mm/">1000mm</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
-              {% endif %}
-              &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
+              <a href="{{site.baseurl}}/1000mm/">1000mm</a> {% if page.parent %}
+              &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
+                {% if page.title %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time-estimate}} minutes</div>
+            {% if page.time_estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad-url1 %}
+            <a class="grabcad-link" href="{{page.grabcad-url1}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad-url2 %}
+            <a class="grabcad-link" href="{{page.grabcad-url2}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad-url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad-url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name2}}</a>
-            {% endif %}
-
           </header>
           <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            {{ content }} {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-          {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
-          {% endif %}
-          {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
-          {% endif %}
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
           </div>
         </div>
       </div>
     </div>
     {% include scripts.html %}
   </body>
-
 </html>

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -1,70 +1,73 @@
 <!DOCTYPE html>
 <html>
 
-  {% include head.html %}
+{% include head.html %}
 
-  <body data-spy="scroll" data-target="#subnav">
+<body data-spy="scroll" data-target="#subnav">
 
-    {% include header.html %}
+  {% include header.html %}
 
-    <div class="instructions-wrapper container">
-      <div id="off-canvas-sidebar">
-        {% include stepnav1000mm.html %}
-        <a id="close" href="#"><i class="fa fa-times"></i></a>
-      </div>
-      <div class="row topic-nav">
-          {% include stepnav1000mm.html %}
-      </div>
-      <div class="row">
-        <div class="page-content js-instruction-step col-sm-7">
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/1000mm/">1000mm</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
+  <div class="instructions-wrapper container">
+    <div id="off-canvas-sidebar">
+      {% include stepnav1000mm.html %}
+      <a id="close" href="#"><i class="fa fa-times"></i></a>
+    </div>
+    <div class="row topic-nav">
+      {% include stepnav1000mm.html %}
+    </div>
+    <div class="row">
+      <div class="page-content js-instruction-step col-sm-7">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/1000mm/">1000mm</a>
+            {% if page.parent %}
+            &#47;
+            {{ page.parent }}
+            {% endif %}
+            &#47;
+            <span class="current-page">
+              {% if page.title %}
+              {{ page.title }}
               {% endif %}
-              &#47;
-              <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-            {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
-            {% endif %}
-
-          </header>
-          <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            </span>
           </div>
+          <h1 class="step-title">{{ page.title }}</h1>
+
+          {% if page.time_estimate %}
+          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
+          {% endif %}
+
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name1}}</a>
+          {% if page.z_axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name2}}</a>
+          {% endif %}
+
+        </header>
+        <div class="step-text">
+          {{ content }}
+          {% include next-step.html %}
         </div>
-        <div class="col-sm-5">
-          <div class="page-diagram">
+      </div>
+      <div class="col-sm-5">
+        <div class="page-diagram">
           {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
           {% endif %}
           {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
           {% endif %}
-          </div>
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -1,71 +1,73 @@
 <!DOCTYPE html>
 <html>
 
-  {% include head.html %}
+{% include head.html %}
 
-  <body data-spy="scroll" data-target="#subnav">
+<body data-spy="scroll" data-target="#subnav">
 
-    {% include header.html %}
+  {% include header.html %}
 
-    <div class="instructions-wrapper container">
-      <div id="off-canvas-sidebar">
-        {% include stepnav500mm.html %}
-        <a id="close" href="#"><i class="fa fa-times"></i></a>
-      </div>
-      <div class="row topic-nav">
-          {% include stepnav500mm.html %}
-      </div>
-      <div class="row">
-        <div class="page-content js-instruction-step col-sm-7">
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/500mm/">500mm</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
+  <div class="instructions-wrapper container">
+    <div id="off-canvas-sidebar">
+      {% include stepnav500mm.html %}
+      <a id="close" href="#"><i class="fa fa-times"></i></a>
+    </div>
+    <div class="row topic-nav">
+      {% include stepnav500mm.html %}
+    </div>
+    <div class="row">
+      <div class="page-content js-instruction-step col-sm-7">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/500mm/">500mm</a>
+            {% if page.parent %}
+            &#47;
+            {{ page.parent }}
+            {% endif %}
+            &#47;
+            <span class="current-page">
+              {% if page.title %}
+              {{ page.title }}
               {% endif %}
-              &#47;
-              <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-            {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
-            {% endif %}
-
-          </header>
-          <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            </span>
           </div>
+          <h1 class="step-title">{{ page.title }}</h1>
+
+          {% if page.time-estimate %}
+          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
+          {% endif %}
+
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name1}}</a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name2}}</a>
+          {% endif %}
+
+        </header>
+        <div class="step-text">
+          {{ content }}
+          {% include next-step.html %}
         </div>
-        <div class="col-sm-5">
-          <div class="page-diagram">
+      </div>
+      <div class="col-sm-5">
+        <div class="page-diagram">
           {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
           {% endif %}
           {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
           {% endif %}
-          </div>
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
 
 </html>

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
+
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
+
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -10,55 +12,60 @@
         {% include stepnav500mm.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">{% include stepnav500mm.html %}</div>
+      <div class="row topic-nav">
+          {% include stepnav500mm.html %}
+      </div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
-              <a href="{{site.baseurl}}/500mm/">500mm</a> {% if page.parent %}
-              &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/500mm/">500mm</a>
+              {% if page.parent %}
+                &#47;
+                  {{ page.parent }}
+              {% endif %}
+              &#47;
               <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
+                {% if page.title %}
+                  {{ page.title }}
+                {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %} {% if page.grabcad-url1 %}
-            <a class="grabcad-link" href="{{page.grabcad-url1}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad-url2 %}
-            <a class="grabcad-link" href="{{page.grabcad-url2}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+            {% if page.time-estimate %}
+            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
             {% endif %}
+
+            {% if page.grabcad-url1 %}
+              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
+              {% if page.z-axis == true %}
+                <span class="grabcad-note">(You're only building part of this now)</span>
+              {% endif %}
+            {% endif %}
+            {% if page.grabcad-url2 %}
+              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
+            {% endif %}
+
           </header>
           <div class="step-text">
-            {{ content }} {% include next-step.html %}
+            {{ content }}
+            {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
+          {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          {% endif %}
+          {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          {% endif %}
           </div>
         </div>
       </div>
     </div>
     {% include scripts.html %}
   </body>
+
 </html>

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
-
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
-
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -12,60 +10,55 @@
         {% include stepnav500mm.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">
-          {% include stepnav500mm.html %}
-      </div>
+      <div class="row topic-nav">{% include stepnav500mm.html %}</div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/500mm/">500mm</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
-              {% endif %}
-              &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
+              <a href="{{site.baseurl}}/500mm/">500mm</a> {% if page.parent %}
+              &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
+                {% if page.title %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time-estimate}} minutes</div>
+            {% if page.time_estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad-url1 %}
+            <a class="grabcad-link" href="{{page.grabcad-url1}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad-url2 %}
+            <a class="grabcad-link" href="{{page.grabcad-url2}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad-url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad-url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name2}}</a>
-            {% endif %}
-
           </header>
           <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            {{ content }} {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-          {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
-          {% endif %}
-          {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
-          {% endif %}
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
           </div>
         </div>
       </div>
     </div>
     {% include scripts.html %}
   </body>
-
 </html>

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -1,70 +1,73 @@
 <!DOCTYPE html>
 <html>
 
-  {% include head.html %}
+{% include head.html %}
 
-  <body data-spy="scroll" data-target="#subnav">
+<body data-spy="scroll" data-target="#subnav">
 
-    {% include header.html %}
+  {% include header.html %}
 
-    <div class="instructions-wrapper container">
-      <div id="off-canvas-sidebar">
-        {% include stepnav750mm.html %}
-        <a id="close" href="#"><i class="fa fa-times"></i></a>
-      </div>
-      <div class="row topic-nav">
-          {% include stepnav750mm.html %}
-      </div>
-      <div class="row">
-        <div class="page-content js-instruction-step col-sm-7">
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/750mm/">750mm</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
+  <div class="instructions-wrapper container">
+    <div id="off-canvas-sidebar">
+      {% include stepnav750mm.html %}
+      <a id="close" href="#"><i class="fa fa-times"></i></a>
+    </div>
+    <div class="row topic-nav">
+      {% include stepnav750mm.html %}
+    </div>
+    <div class="row">
+      <div class="page-content js-instruction-step col-sm-7">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/750mm/">750mm</a>
+            {% if page.parent %}
+            &#47;
+            {{ page.parent }}
+            {% endif %}
+            &#47;
+            <span class="current-page">
+              {% if page.title %}
+              {{ page.title }}
               {% endif %}
-              &#47;
-              <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-            {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
-            {% endif %}
-
-          </header>
-          <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            </span>
           </div>
+          <h1 class="step-title">{{ page.title }}</h1>
+
+          {% if page.time-estimate %}
+          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
+          {% endif %}
+
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name1}}</a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name2}}</a>
+          {% endif %}
+
+        </header>
+        <div class="step-text">
+          {{ content }}
+          {% include next-step.html %}
         </div>
-        <div class="col-sm-5">
-          <div class="page-diagram">
+      </div>
+      <div class="col-sm-5">
+        <div class="page-diagram">
           {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
           {% endif %}
           {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
           {% endif %}
-          </div>
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
+
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
+
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -10,51 +12,55 @@
         {% include stepnav750mm.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">{% include stepnav750mm.html %}</div>
+      <div class="row topic-nav">
+          {% include stepnav750mm.html %}
+      </div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
-              <a href="{{site.baseurl}}/750mm/">750mm</a> {% if page.parent %}
-              &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/750mm/">750mm</a>
+              {% if page.parent %}
+                &#47;
+                  {{ page.parent }}
+              {% endif %}
+              &#47;
               <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
+                {% if page.title %}
+                  {{ page.title }}
+                {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %} {% if page.grabcad-url1 %}
-            <a class="grabcad-link" href="{{page.grabcad-url1}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad-url2 %}
-            <a class="grabcad-link" href="{{page.grabcad-url2}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+            {% if page.time-estimate %}
+            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
             {% endif %}
+
+            {% if page.grabcad-url1 %}
+              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
+              {% if page.z-axis == true %}
+                <span class="grabcad-note">(You're only building part of this now)</span>
+              {% endif %}
+            {% endif %}
+            {% if page.grabcad-url2 %}
+              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
+            {% endif %}
+
           </header>
           <div class="step-text">
-            {{ content }} {% include next-step.html %}
+            {{ content }}
+            {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
+          {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          {% endif %}
+          {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          {% endif %}
           </div>
         </div>
       </div>

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
-
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
-
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -12,60 +10,55 @@
         {% include stepnav750mm.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">
-          {% include stepnav750mm.html %}
-      </div>
+      <div class="row topic-nav">{% include stepnav750mm.html %}</div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/750mm/">750mm</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
-              {% endif %}
-              &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
+              <a href="{{site.baseurl}}/750mm/">750mm</a> {% if page.parent %}
+              &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
+                {% if page.title %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time-estimate}} minutes</div>
+            {% if page.time_estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad-url1 %}
+            <a class="grabcad-link" href="{{page.grabcad-url1}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad-url2 %}
+            <a class="grabcad-link" href="{{page.grabcad-url2}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad-url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad-url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name2}}</a>
-            {% endif %}
-
           </header>
           <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            {{ content }} {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-          {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
-          {% endif %}
-          {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
-          {% endif %}
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
           </div>
         </div>
       </div>
     </div>
     {% include scripts.html %}
   </body>
-
 </html>

--- a/_layouts/defaultupgrade.html
+++ b/_layouts/defaultupgrade.html
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
 <html>
+
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
+
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -10,51 +12,55 @@
         {% include stepnavupgrade.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">{% include stepnavupgrade.html %}</div>
+      <div class="row topic-nav">
+          {% include stepnavupgrade.html %}
+      </div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
-              <a href="{{site.baseurl}}/upgrade/">Upgrade Kit</a> {% if
-              page.parent %} &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/upgrade/">Upgrade Kit</a>
+              {% if page.parent %}
+                &#47;
+                  {{ page.parent }}
+              {% endif %}
+              &#47;
               <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
+                {% if page.title %}
+                  {{ page.title }}
+                {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %} {% if page.grabcad-url1 %}
-            <a class="grabcad-link" href="{{page.grabcad-url1}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad-url2 %}
-            <a class="grabcad-link" href="{{page.grabcad-url2}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+            {% if page.time-estimate %}
+            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
             {% endif %}
+
+            {% if page.grabcad-url1 %}
+              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
+              {% if page.z-axis == true %}
+                <span class="grabcad-note">(You're only building part of this now)</span>
+              {% endif %}
+            {% endif %}
+            {% if page.grabcad-url2 %}
+              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
+            {% endif %}
+
           </header>
           <div class="step-text">
-            {{ content }} {% include next-step.html %}
+            {{ content }}
+            {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
+          {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          {% endif %}
+          {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          {% endif %}
           </div>
         </div>
       </div>

--- a/_layouts/defaultupgrade.html
+++ b/_layouts/defaultupgrade.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
-
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
-
     {% include header.html %}
 
     <div class="instructions-wrapper container">
@@ -12,60 +10,55 @@
         {% include stepnavupgrade.html %}
         <a id="close" href="#"><i class="fa fa-times"></i></a>
       </div>
-      <div class="row topic-nav">
-          {% include stepnavupgrade.html %}
-      </div>
+      <div class="row topic-nav">{% include stepnavupgrade.html %}</div>
       <div class="row">
         <div class="page-content js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/upgrade/">Upgrade Kit</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
-              {% endif %}
-              &#47;
+              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47;
+              <a href="{{site.baseurl}}/upgrade/">Upgrade Kit</a> {% if
+              page.parent %} &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
+                {% if page.title %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time-estimate}} minutes</div>
+            {% if page.time_estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad-url1 %}
+            <a class="grabcad-link" href="{{page.grabcad-url1}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad-url2 %}
+            <a class="grabcad-link" href="{{page.grabcad-url2}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad-url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad-url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name2}}</a>
-            {% endif %}
-
           </header>
           <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            {{ content }} {% include next-step.html %}
           </div>
         </div>
         <div class="col-sm-5">
           <div class="page-diagram">
-          {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
-          {% endif %}
-          {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
-          {% endif %}
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
           </div>
         </div>
       </div>
     </div>
     {% include scripts.html %}
   </body>
-
 </html>

--- a/_layouts/defaultupgrade.html
+++ b/_layouts/defaultupgrade.html
@@ -1,70 +1,73 @@
 <!DOCTYPE html>
 <html>
 
-  {% include head.html %}
+{% include head.html %}
 
-  <body data-spy="scroll" data-target="#subnav">
+<body data-spy="scroll" data-target="#subnav">
 
-    {% include header.html %}
+  {% include header.html %}
 
-    <div class="instructions-wrapper container">
-      <div id="off-canvas-sidebar">
-        {% include stepnavupgrade.html %}
-        <a id="close" href="#"><i class="fa fa-times"></i></a>
-      </div>
-      <div class="row topic-nav">
-          {% include stepnavupgrade.html %}
-      </div>
-      <div class="row">
-        <div class="page-content js-instruction-step col-sm-7">
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/upgrade/">Upgrade Kit</a>
-              {% if page.parent %}
-                &#47;
-                  {{ page.parent }}
+  <div class="instructions-wrapper container">
+    <div id="off-canvas-sidebar">
+      {% include stepnavupgrade.html %}
+      <a id="close" href="#"><i class="fa fa-times"></i></a>
+    </div>
+    <div class="row topic-nav">
+      {% include stepnavupgrade.html %}
+    </div>
+    <div class="row">
+      <div class="page-content js-instruction-step col-sm-7">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/upgrade/">Upgrade Kit</a>
+            {% if page.parent %}
+            &#47;
+            {{ page.parent }}
+            {% endif %}
+            &#47;
+            <span class="current-page">
+              {% if page.title %}
+              {{ page.title }}
               {% endif %}
-              &#47;
-              <span class="current-page">
-                {% if page.title %}
-                  {{ page.title }}
-                {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-            {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name2}}</a>
-            {% endif %}
-
-          </header>
-          <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            </span>
           </div>
+          <h1 class="step-title">{{ page.title }}</h1>
+
+          {% if page.time_estimate %}
+          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
+          {% endif %}
+
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name1}}</a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{page.grabcad_name2}}</a>
+          {% endif %}
+
+        </header>
+        <div class="step-text">
+          {{ content }}
+          {% include next-step.html %}
         </div>
-        <div class="col-sm-5">
-          <div class="page-diagram">
+      </div>
+      <div class="col-sm-5">
+        <div class="page-diagram">
           {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
           {% endif %}
           {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}"/>
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
           {% endif %}
-          </div>
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_layouts/xcarve2015.html
+++ b/_layouts/xcarve2015.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
-
   {% include head.html %}
 
   <body data-spy="scroll" data-target="#subnav">
-
     {% include header.html %}
 
     <div class="instructions-wrapper container-fluid">
@@ -15,51 +13,46 @@
       <div class="row">
         <div class="col-sm-2">
           <a id="hamburger" href="#"><i class="fa fa-bars"></i></a>
-          <div class="sidebar">
-            {% include stepnav2015.html %}
-          </div>
+          <div class="sidebar">{% include stepnav2015.html %}</div>
         </div>
         <div class="page-content2015 js-instruction-step col-sm-7">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Assembly Instructions</a>
-              &#47;
+              <a href="{{site.baseurl}}">X-Carve Assembly Instructions</a> &#47;
               <span class="current-page">
-                {% if page.step-number %}
-                  Step {{ page.step-number }}
-                {% else %}
-                  {{ page.title }}
-                {% endif %}
+                {% if page.step_number %} Step {{ page.step_number }} {% else
+                %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
 
-            {% if page.time-estimate %}
-            <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time-estimate}} minutes</div>
+            {% if page.time_estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad-url1 %}
+            <a class="grabcad-link" href="{{page.grabcad-url1}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad-url2 %}
+            <a class="grabcad-link" href="{{page.grabcad-url2}}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-
-            {% if page.grabcad-url1 %}
-              <a class="grabcad-link" href="{{page.grabcad-url1}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name1}}</a>
-              {% if page.z-axis == true %}
-                <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
-            {% endif %}
-            {% if page.grabcad-url2 %}
-              <a class="grabcad-link" href="{{page.grabcad-url2}}"><i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad-name2}}</a>
-            {% endif %}
-
           </header>
           <div class="step-text">
-            {{ content }}
-            {% include next-step.html %}
+            {{ content }} {% include next-step.html %}
           </div>
         </div>
-        <div class="subnav-container">
-          {% include subnav.html %}
-        </div>
+        <div class="subnav-container">{% include subnav.html %}</div>
       </div>
     </div>
     {% include scripts.html %}
   </body>
-
 </html>

--- a/_layouts/xcarve2015.html
+++ b/_layouts/xcarve2015.html
@@ -20,8 +20,8 @@
             <div class="instruction-breadcrumbs">
               <a href="{{site.baseurl}}">X-Carve Assembly Instructions</a> &#47;
               <span class="current-page">
-                {% if page.step_number %} Step {{ page.step_number }} {% else
-                %} {{ page.title }} {% endif %}
+                {% if page.step_number %} Step {{ page.step_number }} {% else %}
+                {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
@@ -30,7 +30,7 @@
             <div class="time-estimate">
               <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
             </div>
-            {% endif %} {% if page.grabcad-url1 %}
+            {% endif %} {% if page.grabcad_url1 %}
             <a class="grabcad-link" href="{{page.grabcad-url1}}"
               ><i class="fa fa-cube"></i> GrabCAD Model of
               {{ page.grabcad_name1 }}</a
@@ -39,7 +39,7 @@
             <span class="grabcad-note"
               >(You're only building part of this now)</span
             >
-            {% endif %} {% endif %} {% if page.grabcad-url2 %}
+            {% endif %} {% endif %} {% if page.grabcad_url2 %}
             <a class="grabcad-link" href="{{page.grabcad-url2}}"
               ><i class="fa fa-cube"></i> GrabCAD Model of
               {{ page.grabcad_name2 }}</a

--- a/_layouts/xcarve2015.html
+++ b/_layouts/xcarve2015.html
@@ -1,58 +1,56 @@
 <!DOCTYPE html>
 <html>
-  {% include head.html %}
+{% include head.html %}
 
-  <body data-spy="scroll" data-target="#subnav">
-    {% include header.html %}
+<body data-spy="scroll" data-target="#subnav">
+  {% include header.html %}
 
-    <div class="instructions-wrapper container-fluid">
-      <div id="off-canvas-sidebar">
-        {% include stepnav2015.html %}
-        <a id="close" href="#"><i class="fa fa-times"></i></a>
-      </div>
-      <div class="row">
-        <div class="col-sm-2">
-          <a id="hamburger" href="#"><i class="fa fa-bars"></i></a>
-          <div class="sidebar">{% include stepnav2015.html %}</div>
-        </div>
-        <div class="page-content2015 js-instruction-step col-sm-7">
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{site.baseurl}}">X-Carve Assembly Instructions</a> &#47;
-              <span class="current-page">
-                {% if page.step_number %} Step {{ page.step_number }} {% else %}
-                {{ page.title }} {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %} {% if page.grabcad_url1 %}
-            <a class="grabcad-link" href="{{page.grabcad-url1}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad_url2 %}
-            <a class="grabcad-link" href="{{page.grabcad-url2}}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
-            {% endif %}
-          </header>
-          <div class="step-text">
-            {{ content }} {% include next-step.html %}
-          </div>
-        </div>
-        <div class="subnav-container">{% include subnav.html %}</div>
-      </div>
+  <div class="instructions-wrapper container-fluid">
+    <div id="off-canvas-sidebar">
+      {% include stepnav2015.html %}
+      <a id="close" href="#"><i class="fa fa-times"></i></a>
     </div>
-    {% include scripts.html %}
-  </body>
+    <div class="row">
+      <div class="col-sm-2">
+        <a id="hamburger" href="#"><i class="fa fa-bars"></i></a>
+        <div class="sidebar">{% include stepnav2015.html %}</div>
+      </div>
+      <div class="page-content2015 js-instruction-step col-sm-7">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{site.baseurl}}">X-Carve Assembly Instructions</a> &#47;
+            <span class="current-page">
+              {% if page.step_number %} Step {{ page.step_number }} {% else %}
+              {{ page.title }} {% endif %}
+            </span>
+          </div>
+          <h1 class="step-title">{{ page.title }}</h1>
+
+          {% if page.time_estimate %}
+          <div class="time-estimate">
+            <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+          </div>
+          {% endif %}
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{ page.grabcad_name1 }}</a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
+            {{ page.grabcad_name2 }}</a>
+          {% endif %}
+        </header>
+        <div class="step-text">
+          {{ content }} {% include next-step.html %}
+        </div>
+      </div>
+      <div class="subnav-container">{% include subnav.html %}</div>
+    </div>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -26,12 +26,15 @@ header {
   padding-left: 0;
 }
 
-.navbar-default {
+.navbar-expand-lg {
   background: none;
   border: none;
   border-radius: 0;
   margin-bottom: 0;
-  margin-left: 5px;
+  @media (min-width: 1200px) {
+      display: flex;
+      align-items: center;
+  }
 }
 
 .search-container {
@@ -341,7 +344,6 @@ border-bottom: 1px solid #fff;
   text-transform: none !important;
   top: 6px;
   left: 10px;
-  width: 208px;
   box-shadow: 2px 2px 2px rgba(0,0,0,.1);
   transition: box-shadow .3s ease;
   letter-spacing: 0 !important;

--- a/upgrade/step1/index.md
+++ b/upgrade/step1/index.md
@@ -4,8 +4,8 @@ title: "Side Board"
 step_number: 1
 redirect_from: "/upgrade/"
 permalink: /upgrade/step1/
-next-step: /upgrade/step2/
-next-step-title: "Wide Makerslide"
+next_step: /upgrade/step2/
+next_step_title: "Wide Makerslide"
 ---
 
 <div class="bom">

--- a/upgrade/step1/index.md
+++ b/upgrade/step1/index.md
@@ -1,7 +1,7 @@
 ---
 layout: defaultupgrade
 title: "Side Board"
-step-number: 1
+step_number: 1
 redirect_from: "/upgrade/"
 permalink: /upgrade/step1/
 next-step: /upgrade/step2/

--- a/upgrade/step2/index.md
+++ b/upgrade/step2/index.md
@@ -1,7 +1,7 @@
 ---
 layout: defaultupgrade
 title: "Wide Makerslide"
-step-number: 1
+step_number: 1
 permalink: /upgrade/step2/
 next-step: /upgrade/step3/1assembly/
 next-step-title: "X-Controller"

--- a/upgrade/step2/index.md
+++ b/upgrade/step2/index.md
@@ -3,8 +3,8 @@ layout: defaultupgrade
 title: "Wide Makerslide"
 step_number: 1
 permalink: /upgrade/step2/
-next-step: /upgrade/step3/1assembly/
-next-step-title: "X-Controller"
+next_step: /upgrade/step3/1assembly/
+next_step_title: "X-Controller"
 ---
 
 Note: In these photos, we will be installing the wide MakerSlide on a 500mm sized X-Carve, circa 2015. Some of the exact parts on your machine will be slightly different, but you should still use these instructions to get the general idea of what steps are necessary to swap our your x-axis gantry with the wide MakerSlide rail. 

--- a/upgrade/step3/1assembly/index.md
+++ b/upgrade/step3/1assembly/index.md
@@ -2,7 +2,7 @@
 layout: defaultupgrade
 title: "X-Controller Assembly"
 parent: X-Controller
-step-number: 1
+step_number: 1
 redirect_from: "/upgrade/step3/"
 permalink: /upgrade/step3/1assembly/
 next-step: /upgrade/step3/2usage/

--- a/upgrade/step3/1assembly/index.md
+++ b/upgrade/step3/1assembly/index.md
@@ -5,8 +5,8 @@ parent: X-Controller
 step_number: 1
 redirect_from: "/upgrade/step3/"
 permalink: /upgrade/step3/1assembly/
-next-step: /upgrade/step3/2usage/
-next-step-title: "Usage"
+next_step: /upgrade/step3/2usage/
+next_step_title: "Usage"
 ---
 
 <img src="../../../../1000mm/step8/PB231421BATCH201.jpg">

--- a/upgrade/step3/2usage/index.md
+++ b/upgrade/step3/2usage/index.md
@@ -4,8 +4,8 @@ title: "X-Controller Usage"
 parent: X-Conroller
 step_number: 2
 permalink: /upgrade/step3/2usage/
-next-step: /upgrade/step4/
-next-step-title: "Z-Probe"
+next_step: /upgrade/step4/
+next_step_title: "Z-Probe"
 ---
 
 <h1>Usage Instructions</h1>

--- a/upgrade/step3/2usage/index.md
+++ b/upgrade/step3/2usage/index.md
@@ -2,7 +2,7 @@
 layout: defaultupgrade
 title: "X-Controller Usage"
 parent: X-Conroller
-step-number: 2
+step_number: 2
 permalink: /upgrade/step3/2usage/
 next-step: /upgrade/step4/
 next-step-title: "Z-Probe"

--- a/upgrade/step4/index.md
+++ b/upgrade/step4/index.md
@@ -1,7 +1,7 @@
 ---
 layout: defaultupgrade
 title: "Z-Probe"
-step-number: 4
+step_number: 4
 permalink: /upgrade/step4/
 next-step: /upgrade/step5/
 next-step-title: "Dust Control System"

--- a/upgrade/step4/index.md
+++ b/upgrade/step4/index.md
@@ -3,8 +3,8 @@ layout: defaultupgrade
 title: "Z-Probe"
 step_number: 4
 permalink: /upgrade/step4/
-next-step: /upgrade/step5/
-next-step-title: "Dust Control System"
+next_step: /upgrade/step5/
+next_step_title: "Dust Control System"
 ---
 
 Installing your z-probe will be different depending on if you have a hole on the upper right corner of your x-carriage or not. Before starting, check to see if your x-carriage has this hole or not. The instructions are essentially the same for both x-carriage types, but there are some differences. 

--- a/upgrade/step5/index.md
+++ b/upgrade/step5/index.md
@@ -1,7 +1,7 @@
 ---
 layout: defaultupgrade
 title: "Dust Control System"
-step-number: 5
+step_number: 5
 permalink: /upgrade/step5/
 ---
 

--- a/xcarve2015/step02/index.md
+++ b/xcarve2015/step02/index.md
@@ -5,11 +5,11 @@ time_estimate: 60
 category: step
 step_number: 2
 permalink: /xcarve2015/step02/
-next-step: /xcarve2015/step03/
+next_step: /xcarve2015/step03/
 redirect_from: "/step02/"
-next-step-title: "Y-Plates"
+next_step_title: "Y-Plates"
 grabcad_name1: "X Carriage"
-grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/156177"
+grabcad_url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/156177"
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/Pts70Si3aTI" frameborder="0" allowfullscreen>

--- a/xcarve2015/step02/index.md
+++ b/xcarve2015/step02/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "X Carriage"
-time-estimate: 60
+title: "X Carriage"
+time_estimate: 60
 category: step
-step-number: 2
+step_number: 2
 permalink: /xcarve2015/step02/
 next-step: /xcarve2015/step03/
 redirect_from: "/step02/"
 next-step-title: "Y-Plates"
-grabcad-name1: "X Carriage"
+grabcad_name1: "X Carriage"
 grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/156177"
 ---
 
@@ -143,7 +143,7 @@ The eccentric nuts on your X-Carve are a slick little example of good engineerin
 
 ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/666/original/0066.jpg?1424461342)
 
-This animation illustrates how the eccentric nuts change the position of the v-wheels.  Keep the eccentric nuts in the "open" position for the time being, so you can easily insert the Makerslide rail in next steps.  You will make the eccentric nut adjustments later on in the Calibrate section.
+This animation illustrates how the eccentric nuts change the position of the v-wheels. Keep the eccentric nuts in the "open" position for the time being, so you can easily insert the Makerslide rail in next steps. You will make the eccentric nut adjustments later on in the Calibrate section.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/nX0J317l0mY" frameborder="0" allowfullscreen></iframe>
 

--- a/xcarve2015/step03/index.md
+++ b/xcarve2015/step03/index.md
@@ -1,16 +1,16 @@
 ---
 layout: xcarve2015
-title:  "Y Plates"
-time-estimate: 30
+title: "Y Plates"
+time_estimate: 30
 category: step
-step-number: 3
+step_number: 3
 permalink: /xcarve2015/step03/
 next-step: /xcarve2015/step04/
 redirect_from: "/step02/"
 next-step-title: "Gantry"
-grabcad-name1: "Left Y-Plate"
+grabcad_name1: "Left Y-Plate"
 grabcad-url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125930
-grabcad-name2: "Right Y-Plate"
+grabcad_name2: "Right Y-Plate"
 grabcad-url2: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125932
 ---
 

--- a/xcarve2015/step03/index.md
+++ b/xcarve2015/step03/index.md
@@ -5,13 +5,13 @@ time_estimate: 30
 category: step
 step_number: 3
 permalink: /xcarve2015/step03/
-next-step: /xcarve2015/step04/
+next_step: /xcarve2015/step04/
 redirect_from: "/step02/"
-next-step-title: "Gantry"
+next_step_title: "Gantry"
 grabcad_name1: "Left Y-Plate"
-grabcad-url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125930
+grabcad_url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125930
 grabcad_name2: "Right Y-Plate"
-grabcad-url2: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125932
+grabcad_url2: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125932
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/mmIVaf1D2kU" frameborder="0" allowfullscreen>

--- a/xcarve2015/step04/index.md
+++ b/xcarve2015/step04/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "Gantry"
-time-estimate: 45
+title: "Gantry"
+time_estimate: 45
 category: step
-step-number: 4
+step_number: 4
 permalink: /xcarve2015/step04/
 next-step: /xcarve2015/step05/
 redirect_from: "/step04/"
 next-step-title: "Y-Axis"
-grabcad-name1: "Gantry"
+grabcad_name1: "Gantry"
 grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125929"
 ---
 
@@ -90,11 +90,11 @@ Some kits may include M5 × 12mm button head cap screws, qty 18. These replace t
 <h3 id="attach-makerslide">
 1. Attach the Makerslide to the Right Y Motor Plate</h3>
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/730/original/1329.jpg?1424543603)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/730/original/1329.jpg?1424543603)
 
 You'll be using two pieces of Makerslide to create an X-Axis. Make sure to grab the MakerSlide with the X-Carve logo. **The logo will be oriented on the right side of the machine facing front.** You’ll start by attaching the right Y-Plate to one piece of Makerslide. Orient the Makerslide and Y-Plate like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/731/original/1336.jpg?1424543604)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/731/original/1336.jpg?1424543604)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>
@@ -117,7 +117,7 @@ Next you’ll attach another piece of Makerslide to the right Y-Plate with two m
 <div class="row image-row"><img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/736/original/1346.jpg?1424543838" class="thumbnail col-md-3" alt="" /> <img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/737/original/1348.jpg?1424543839" class="thumbnail col-md-3" alt="" /> <img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/738/original/1356.jpg?1424543840" class="thumbnail col-md-3" alt="" /> <img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/739/original/1358.jpg?1424543841" class="thumbnail col-md-3" alt="" /></div>
 Your X-Axis should look like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/740/original/1362.jpg?1424543842)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/740/original/1362.jpg?1424543842)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>
@@ -131,11 +131,11 @@ Your X-Axis should look like this:
 
 Now you’ll slide the X Carriage onto the x-axis. Be gentle with this step as it’s easy to mar the V-Wheels on the sharp edges of the Makerslide if you’re not careful. If you’re finding that the Makerslide doesn't quite fit in between the V-Wheels check that the eccentric nuts on the X Carriage are in the “open” position. If they are the screws that hold them in place will be as far from the top V-Wheels as possible.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/743/original/0069.jpg?1424544268)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/743/original/0069.jpg?1424544268)
 
 Line up the rails of the X-Axis Makerslide with the V-Wheels of the X Carriage like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/741/original/1371.jpg?1424543843)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/741/original/1371.jpg?1424543843)
 
 Slide the X Carriage midway along the X-Axis and set the assembly down.
 
@@ -144,11 +144,11 @@ Slide the X Carriage midway along the X-Axis and set the assembly down.
 
 Before you attach the left Y-Plate to the X-axis, slide two insertion nuts into the rear X-axis Makerslide (the one that is closest to the X-Motor). You’ll use these to attach belt clips later.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/742/original/1372.jpg?1424543844)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/742/original/1372.jpg?1424543844)
 
 <h3 id="makerslide-left-y-plate">
 5. Attach Left Y Motor Plate and Makerslide</h3>
 
 Now repeat the process you used to attach the right Y-Plate to the X-axis. You should have an assembly that looks like this when you’re done:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/533/original/0957.jpg?1424361798)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/533/original/0957.jpg?1424361798)

--- a/xcarve2015/step04/index.md
+++ b/xcarve2015/step04/index.md
@@ -5,11 +5,11 @@ time_estimate: 45
 category: step
 step_number: 4
 permalink: /xcarve2015/step04/
-next-step: /xcarve2015/step05/
+next_step: /xcarve2015/step05/
 redirect_from: "/step04/"
-next-step-title: "Y-Axis"
+next_step_title: "Y-Axis"
 grabcad_name1: "Gantry"
-grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125929"
+grabcad_url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125929"
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/fSk9E95GFyQ" frameborder="0" allowfullscreen>

--- a/xcarve2015/step05/index.md
+++ b/xcarve2015/step05/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "Y-Axis"
-time-estimate: 45
+title: "Y-Axis"
+time_estimate: 45
 category: step
-step-number: 5
+step_number: 5
 permalink: /xcarve2015/step05/
 next-step: /xcarve2015/step06/
 redirect_from: "/step05/"
 next-step-title: "Belting"
-grabcad-name1: "Y-Axis"
+grabcad_name1: "Y-Axis"
 grabcad-url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125936
 ---
 
@@ -80,7 +80,7 @@ Attach a piece of Makerslide to an end plate using a button head cap screw. Make
 </div>
 Repeat this process with another piece of Makerslide and another end plate, but mirror the piece you made in the previous step. You should have two pieces like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/538/original/0352.jpg?1424363297)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/538/original/0352.jpg?1424363297)
 
 <h3 id="slide-on-gantry">
 2. Slide on Gantry</h3>
@@ -96,7 +96,7 @@ Now you’ll slide the gantry onto each of the Y-axes. This step is just like wh
 
 Put two insertion nuts into each piece of y-axis Makerslide (four in total).
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/539/original/0407.jpg?1424363342)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/539/original/0407.jpg?1424363342)
 
 <h3 id="attach-front-end-plates">
 4. Attach Front End Plates</h3>
@@ -109,7 +109,7 @@ Now put the last two end plates on the y-axis Makerslide with button head cap sc
 
 Your X-Carve should look like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/540/original/0377.jpg?1424363386)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/540/original/0377.jpg?1424363386)
 
 <h3 id="connect-end-plates">
 5. Connect End Plates with Extrusions</h3>
@@ -159,7 +159,7 @@ Your X-Carve should look like this:
 
 You’ll connect the two y-axes with extrusions in the front and back of the machine.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/541/original/0379.jpg?1424363431)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/541/original/0379.jpg?1424363431)
 
 Slide the insertion nuts into the extrusions and fasten the end plates to them with 8mm screws:
 
@@ -175,4 +175,4 @@ Slide the insertion nuts into the extrusions and fasten the end plates to them w
 </div>
 Your X-Carve should look like this now:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/536/original/0398.jpg?1424363196)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/536/original/0398.jpg?1424363196)

--- a/xcarve2015/step05/index.md
+++ b/xcarve2015/step05/index.md
@@ -5,11 +5,11 @@ time_estimate: 45
 category: step
 step_number: 5
 permalink: /xcarve2015/step05/
-next-step: /xcarve2015/step06/
+next_step: /xcarve2015/step06/
 redirect_from: "/step05/"
-next-step-title: "Belting"
+next_step_title: "Belting"
 grabcad_name1: "Y-Axis"
-grabcad-url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125936
+grabcad_url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125936
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/pRSegK2lujI" frameborder="0" allowfullscreen>

--- a/xcarve2015/step06/index.md
+++ b/xcarve2015/step06/index.md
@@ -5,9 +5,9 @@ time_estimate: 15
 category: step
 step_number: 6
 permalink: /xcarve2015/step06/
-next-step: /xcarve2015/step07/
+next_step: /xcarve2015/step07/
 redirect_from: "/step06/"
-next-step-title: "Z-Axis"
+next_step_title: "Z-Axis"
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/JXco1gg48Y8" frameborder="0" allowfullscreen>

--- a/xcarve2015/step06/index.md
+++ b/xcarve2015/step06/index.md
@@ -1,9 +1,9 @@
 ---
 layout: xcarve2015
-title:  "Belting"
-time-estimate: 15
+title: "Belting"
+time_estimate: 15
 category: step
-step-number: 6
+step_number: 6
 permalink: /xcarve2015/step06/
 next-step: /xcarve2015/step07/
 redirect_from: "/step06/"
@@ -97,7 +97,7 @@ Now that you've got the X and Y axes assembled let's put belts on them. Start by
 
 Aligning the pulley on your x-axis motor with the smooth idlers on either side of it will ensure that the belt travels smoothly. To adjust the placement of the pulley on the motor shaft loosen the two set screws a full turn. Move the pulley so that the outer lip lines up with the outer lip of the smooth idlers.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/629/original/0470.jpg?1424385910)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/629/original/0470.jpg?1424385910)
 
 When you've got the pulley in the right place tighten the set screws with moderate force.
 
@@ -106,7 +106,7 @@ When you've got the pulley in the right place tighten the set screws with modera
 
 Next you’ll be threading a length of belt between the pulley and one idler. It helps a lot to curl the end of the belt beforehand:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/754/original/1446.jpg?1424546350)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/754/original/1446.jpg?1424546350)
 
 Insert the belt between the pulley and the left idler from the top. Make sure the belt goes in with its teeth facing down and that it goes underneath the idler.
 
@@ -115,17 +115,17 @@ Insert the belt between the pulley and the left idler from the top. Make sure th
 
 Curl the other end and insert it on the right side of the pulley.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/633/original/0479.jpg?1424386059)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/633/original/0479.jpg?1424386059)
 
 One side of this belt is going to stay put all of the time, we’ll call that side static. The other side of the belt will be adjustable so that you can tune its tension, we’ll call that side dynamic.
 
 You’ll start with the static side on the left of the machine. Thread the belt through as shown, be sure to check that the belt is running through the slots in the proper order and that the teeth are facing the correct way.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/634/original/0487.jpg?1424386060)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/634/original/0487.jpg?1424386060)
 
 If you’ve looped the belt through correctly the teeth should mate like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/635/original/0483.jpg?1424386061)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/635/original/0483.jpg?1424386061)
 
 Next you’ll attach this belt clip to the Makerslide. Insert the smaller screw into the hole on the belt clip and screw it almost all of the way down.
 
@@ -134,17 +134,17 @@ Next you’ll attach this belt clip to the Makerslide. Insert the smaller screw 
 
 Flush the belt clip with the Y-Motor Plate and tighten the screw as much as you can without stripping the head. It may help to place a zip tie or some electrical tape around the doubled-over cable, close to the clip, to help keep the belt's teeth engaged.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/757/original/1428.jpg?1424546353)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/757/original/1428.jpg?1424546353)
 
 Thread the other end of the belt through another belt clip.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/844/original/1433.jpg?1425393670)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/844/original/1433.jpg?1425393670)
 
 Put an M5 x 25mm button head cap screw through the top hole on the belt clip and then put an M5 x 8mm button head cap screw through the bottom hole.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/845/original/1434.jpg?1425393670)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/845/original/1434.jpg?1425393670)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/846/original/1435.jpg?1425393672)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/846/original/1435.jpg?1425393672)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>
@@ -155,9 +155,9 @@ Put an M5 x 25mm button head cap screw through the top hole on the belt clip and
 </div>
 Tighten the 8mm screw into the insertion nut in the Makerslide all of the way down and then back it off **less than a quarter of a turn**. If you loosen this screw too much the belt will slip when you tighten it. Slide the belt clip along the X-Axis and push the 25mm screw through the hole in the right Y Motor Plate.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/847/original/1438.jpg?1425393672)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/847/original/1438.jpg?1425393672)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/848/original/1440.jpg?1425393673)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/848/original/1440.jpg?1425393673)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>

--- a/xcarve2015/step07/index.md
+++ b/xcarve2015/step07/index.md
@@ -5,12 +5,12 @@ time_estimate: 30
 category: step
 step_number: 7
 permalink: /xcarve2015/step07/
-next-step: /xcarve2015/step08/
+next_step: /xcarve2015/step08/
 redirect_from: "/step07/"
-next-step-title: "Drive Rod"
+next_step_title: "Drive Rod"
 grabcad_name1: "Z-Axis Assembly"
-grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125928"
-z-axis: true
+grabcad_url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125928"
+z_axis: true
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/80KqP6JMXZc" frameborder="0" allowfullscreen>

--- a/xcarve2015/step07/index.md
+++ b/xcarve2015/step07/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "Z-Axis"
-time-estimate: 30
+title: "Z-Axis"
+time_estimate: 30
 category: step
-step-number: 7
+step_number: 7
 permalink: /xcarve2015/step07/
 next-step: /xcarve2015/step08/
 redirect_from: "/step07/"
 next-step-title: "Drive Rod"
-grabcad-name1: "Z-Axis Assembly"
+grabcad_name1: "Z-Axis Assembly"
 grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125928"
 z-axis: true
 ---
@@ -63,22 +63,22 @@ z-axis: true
 
 Insert the flanged bearing into the Z-Plate as shown. Be sure to insert the bearing from the side of the plate that has a recession, the bearing will sit inside the hole so that the flange is flush with the Z-Plate.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/542/original/0952.jpg?1424364483)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/542/original/0952.jpg?1424364483)
 
 Insert two small screws to hold the bearing captive. Finger tighten both and check to make sure the flange is flush with the Z-Plate. Then tighten them down with moderate force.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/543/original/0953.jpg?1424364526)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/543/original/0953.jpg?1424364526)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/544/original/0954.jpg?1424364537)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/544/original/0954.jpg?1424364537)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/545/original/0956.jpg?1424364548)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/545/original/0956.jpg?1424364548)
 
 <h3 id="attach-z-plate">
 2. Attach the Z-Plate to the Z-Axis Makerslide</h3>
 
 Before you attach the Z-Axis Makerslide to the Z-Plate be sure that you have the correct orientation:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/546/original/0959.jpg?1424378497)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/546/original/0959.jpg?1424378497)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>
@@ -89,11 +89,11 @@ Before you attach the Z-Axis Makerslide to the Z-Plate be sure that you have the
 </div>
 Use the two longer button head cap screws to attach the Z-Plate to the Z-Axis Makerslide. The screws go through the Z-Plate and into the Makerslide.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/547/original/0963.jpg?1424378546)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/547/original/0963.jpg?1424378546)
 
 When you're done your Z-Axis should look like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/548/original/0967.jpg?1424378581)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/548/original/0967.jpg?1424378581)
 
 <h3 id="attach-z-axis">
 3. Attach the Z-Axis to the X Carriage</h3>
@@ -120,35 +120,35 @@ When you're done your Z-Axis should look like this:
 </table>
 Push two screws through the top Z-Axis mounting holes on the X Carriage.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/549/original/0524.jpg?1424378647)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/549/original/0524.jpg?1424378647)
 
 Thread two insertion nuts onto these screws. You'll only need a couple of threads to grab.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/550/original/0526.jpg?14243786941)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/550/original/0526.jpg?14243786941)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/551/original/0527.jpg?1424378704)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/551/original/0527.jpg?1424378704)
 
 The backside of the Z-Axis Makerslide has two slots that are designed to accept insertion nuts. Slide these slots over the insertion nuts.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/552/original/0533.jpg?1424378767)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/552/original/0533.jpg?1424378767)
 
 Slide the Z-Axis down along the X Carriage to about here and tighten:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/553/original/0535.jpg?1424378780)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/553/original/0535.jpg?1424378780)
 
 Rock the machine onto its front like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/554/original/0539.jpg?1424378866)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/554/original/0539.jpg?1424378866)
 
 Insert two more insertion nuts from the bottom of the Z-Axis and finger tighten two screws into them to secure the Z-Axis Makerslide:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/556/original/0541.jpg?1424378946)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/556/original/0541.jpg?1424378946)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/559/original/0544.jpg?1424378949)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/559/original/0544.jpg?1424378949)
 
 The Z-Axis should be captured by four insertion nuts and screws at this point, but you should still be able to slide it up and down the X Carriage. Slide it so that the insertion nuts are just inside of the Makerslide like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/560/original/0546.jpg?1424379091)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/560/original/0546.jpg?1424379091)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>
@@ -161,7 +161,7 @@ Tighten all four screws that capture the Z-Axis. Alternate between screws in an 
 
 Rock the machine back on to its feet again to continue:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/561/original/0580.jpg?1424379102)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/561/original/0580.jpg?1424379102)
 
 <h3 id="limit-switch">
 4. Mounting Z-Axis Limit Switch</h3>

--- a/xcarve2015/step08/index.md
+++ b/xcarve2015/step08/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "Drive Rod"
-time-estimate: 15
+title: "Drive Rod"
+time_estimate: 15
 category: step
-step-number: 8
+step_number: 8
 permalink: /xcarve2015/step08/
 next-step: /xcarve2015/step09/
 redirect_from: "/step08/"
 next-step-title: "Z-Axis Motor"
-grabcad-name1: "Z-Axis Assembly"
+grabcad_name1: "Z-Axis Assembly"
 grabcad-url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125928
 z-axis: true
 ---

--- a/xcarve2015/step08/index.md
+++ b/xcarve2015/step08/index.md
@@ -5,12 +5,12 @@ time_estimate: 15
 category: step
 step_number: 8
 permalink: /xcarve2015/step08/
-next-step: /xcarve2015/step09/
+next_step: /xcarve2015/step09/
 redirect_from: "/step08/"
-next-step-title: "Z-Axis Motor"
+next_step_title: "Z-Axis Motor"
 grabcad_name1: "Z-Axis Assembly"
-grabcad-url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125928
-z-axis: true
+grabcad_url1: https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/125928
+z_axis: true
 ---
 
 <img src="0579.jpg">

--- a/xcarve2015/step09/index.md
+++ b/xcarve2015/step09/index.md
@@ -5,9 +5,9 @@ time_estimate: 15
 category: step
 step_number: 9
 permalink: /xcarve2015/step09/
-next-step: /xcarve2015/step10/
+next_step: /xcarve2015/step10/
 redirect_from: "/step09/"
-next-step-title: "Wiring"
+next_step_title: "Wiring"
 ---
 
 <img src="0607.jpg">

--- a/xcarve2015/step09/index.md
+++ b/xcarve2015/step09/index.md
@@ -1,9 +1,9 @@
 ---
 layout: xcarve2015
-title:  "Z-Axis Motor"
-time-estimate: 15
+title: "Z-Axis Motor"
+time_estimate: 15
 category: step
-step-number: 9
+step_number: 9
 permalink: /xcarve2015/step09/
 next-step: /xcarve2015/step10/
 redirect_from: "/step09/"

--- a/xcarve2015/step10/index.md
+++ b/xcarve2015/step10/index.md
@@ -5,9 +5,9 @@ time_estimate: 45
 category: step
 step_number: 10
 permalink: /xcarve2015/step10/
-next-step: /xcarve2015/step11/
+next_step: /xcarve2015/step11/
 redirect_from: "/step10/"
-next-step-title: "Drag Chain"
+next_step_title: "Drag Chain"
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/_vCIVagKgzA" frameborder="0" allowfullscreen>

--- a/xcarve2015/step10/index.md
+++ b/xcarve2015/step10/index.md
@@ -1,9 +1,9 @@
 ---
 layout: xcarve2015
-title:  "Wiring"
-time-estimate: 45
+title: "Wiring"
+time_estimate: 45
 category: step
-step-number: 10
+step_number: 10
 permalink: /xcarve2015/step10/
 next-step: /xcarve2015/step11/
 redirect_from: "/step10/"
@@ -17,7 +17,7 @@ next-step-title: "Drag Chain"
 
 First you'll trim the excess wire from each stepper motor and strip each wire of each stepper motor (16 in total). You'll want about 1/4" of bare wire showing.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/770/original/0673.jpg?1425054295)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/770/original/0673.jpg?1425054295)
 
 <h3 id="secure-wires">
 2. Secure Wires in Terminal Blocks</h3>
@@ -26,17 +26,17 @@ Next insert the stepper motor wires for the X and Z motors into the correspondin
 
 #### X-Motor
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/762/original/0678.jpg?1425052768)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/762/original/0678.jpg?1425052768)
 
 #### Z-Motor
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/763/original/0686.jpg?1425052769)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/763/original/0686.jpg?1425052769)
 
 #### Right Y-Motor
 
 Next insert the stepper motor wires for the **right Y-Motor** into the corresponding terminal block. To keep wiring consistent work from left to right and keep the order of <span style="color:red">**red**</span>, <span style="color:blue">**blue**</span>, <span style="color:green">**green**</span> and <span style="color:black">**black**</span>.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/764/original/0694.jpg?1425052770)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/764/original/0694.jpg?1425052770)
 
 <h3 id="prepare-stepper-cable">
 3. Prepare Stepper Cable</h3>
@@ -90,34 +90,34 @@ Strip one end of each piece of stepper cable. There is grey insulation around al
 <div class="row image-row"><img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/771/original/1060.jpg?1425054296" class="thumbnail col-md-3" alt="" /> <img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/772/original/1061.jpg?1425054297" class="thumbnail col-md-3" alt="" /> <img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/773/original/1062.jpg?1425054298" class="thumbnail col-md-3" alt="" /> <img src="https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/774/original/1063.jpg?1425054298" class="thumbnail col-md-3" alt="" /></div>
 Strip about 1/4" of each of these colored wires.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/775/original/1066.jpg?1425054522)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/775/original/1066.jpg?1425054522)
 
 <h3 id="secure-stepper-cable">
 4. Secure Stepper Cable in Terminal Blocks</h3>
 
 Take the shortest length of stepper cable and wire it to the terminal block on the right Y-Plate. Match <span style="color:red">**red**</span> to <span style="color:red">**red**</span>, **white** to <span style="color:blue">**blue**</span>, <span style="color: green">**green**</span> to <span style="color:green">**green**</span> and <span style="color:black">**black**</span> to <span style="color:black">**black**</span>.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/776/original/0700.jpg?1425054523)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/776/original/0700.jpg?1425054523)
 
 Put the other end of this piece of stepper cable in to this hole and thread it through the X-Axis of the machine:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/777/original/0702.jpg?1425054524)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/777/original/0702.jpg?1425054524)
 
 When you get the end through the same hole on the left Y-Plate strip it as before. Now you'll twist these wires with the left Y-Motor wires. Twist them as follows: <span style="color:red">**red**</span> to **white**, <span style="color:blue">**blue**</span> to <span style="color:red">**red**</span>, <span style="color:green">**green**</span> to <span style="color:green">**green**</span>, and <span style="color:black">**black**</span> to <span style="color:black">**black**</span>. Insert them into the terminal block one pair at a time. When you're done your left Y-Plate should look like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/778/original/0717.jpg?1425054525)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/778/original/0717.jpg?1425054525)
 
 Ok, that was the hardest part of the wiring. Now you'll wire the x-axis motor. Use one of the longest pieces of stepper cable and wire into the terminal block under the x-axis motor. Match <span style="color:red">**red**</span> to <span style="color:red">**red**</span>, <span style="color:blue">**blue**</span> to **white**, <span style="color:green">**green**</span> to <span style="color:green">**green**</span> and <span style="color:black">**black**</span> to <span style="color:black">**black**</span>. Repeat the process with the other long piece of stepper cable for the z-motor. When you're done you should have something like this:
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/779/original/0719.jpg?1425054807)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/779/original/0719.jpg?1425054807)
 
 If you purchased a 24V or 48V spindle with your X-Carve kit now is a good time to attach the zip wire that will eventually power it. Pull the <span style="color:black">**black**</span> and <span style="color:red">**red**</span> wires away from each other and strip the ends leaving about 1/4" bare. Wire them into the bottom of the terminal block in the two spaces you left open. Use the left terminal for <span style="color:red">**red**</span> and the right terminal for <span style="color:black">**black**</span>.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/780/original/0735.jpg?14250548081)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/780/original/0735.jpg?14250548081)
 
 Now you'll wire the left y-axis motor. Use your last piece of stepper cable and wire into the bottom of the terminal block on the left Y-Plate in the order of <span style="color:red">**red**</span>, **white**, <span style="color:green">**green**</span>, and <span style="color:black">**black**</span>.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/781/original/0722.jpg?1425054808)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/781/original/0722.jpg?1425054808)
 
 This diagram should help clarify this step, and will be referenced again when you wire your stepper cable to the gShield in the Electronics section.
 

--- a/xcarve2015/step11/index.md
+++ b/xcarve2015/step11/index.md
@@ -1,16 +1,16 @@
 ---
 layout: xcarve2015
-title:  "Drag Chain"
-time-estimate: 20
+title: "Drag Chain"
+time_estimate: 20
 category: step
-step-number: 11
+step_number: 11
 permalink: /xcarve2015/step11/
 next-step: /xcarve2015/step12/
 redirect_from: "/step11/"
 next-step-title: "Spindle Mount"
-grabcad-name1: "500mm Drag Chain"
+grabcad_name1: "500mm Drag Chain"
 grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/155522"
-grabcad-name2: "1000m Drag Chain"
+grabcad_name2: "1000m Drag Chain"
 grabcad-url2: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/155521"
 ---
 

--- a/xcarve2015/step11/index.md
+++ b/xcarve2015/step11/index.md
@@ -5,13 +5,13 @@ time_estimate: 20
 category: step
 step_number: 11
 permalink: /xcarve2015/step11/
-next-step: /xcarve2015/step12/
+next_step: /xcarve2015/step12/
 redirect_from: "/step11/"
-next-step-title: "Spindle Mount"
+next_step_title: "Spindle Mount"
 grabcad_name1: "500mm Drag Chain"
-grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/155522"
+grabcad_url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/155522"
 grabcad_name2: "1000m Drag Chain"
-grabcad-url2: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/155521"
+grabcad_url2: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/155521"
 ---
 
 <img src="XCarveDragChain.jpg">

--- a/xcarve2015/step12/index.md
+++ b/xcarve2015/step12/index.md
@@ -5,11 +5,11 @@ time_estimate: 25
 category: step
 step_number: 12
 permalink: /xcarve2015/step12/
-next-step: /xcarve2015/step13/
+next_step: /xcarve2015/step13/
 redirect_from: "/step12/"
-next-step-title: "Work Area"
+next_step_title: "Work Area"
 grabcad_name1: "Spindle Carriage"
-grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/217354"
+grabcad_url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/217354"
 ---
 
 For mounting instructions, select your spindle choice below.

--- a/xcarve2015/step12/index.md
+++ b/xcarve2015/step12/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "Spindle Mount"
-time-estimate: 25
+title: "Spindle Mount"
+time_estimate: 25
 category: step
-step-number: 12
+step_number: 12
 permalink: /xcarve2015/step12/
 next-step: /xcarve2015/step13/
 redirect_from: "/step12/"
 next-step-title: "Work Area"
-grabcad-name1: "Spindle Carriage"
+grabcad_name1: "Spindle Carriage"
 grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/217354"
 ---
 

--- a/xcarve2015/step14/index.md
+++ b/xcarve2015/step14/index.md
@@ -1,14 +1,14 @@
 ---
 layout: xcarve2015
-title:  "Electronics"
-time-estimate: 45
+title: "Electronics"
+time_estimate: 45
 category: step
-step-number: 14
+step_number: 14
 permalink: /xcarve2015/step14/
 next-step: /xcarve2015/step15/
 redirect_from: "/step14/"
 next-step-title: "Calibrate"
-grabcad-name1: "X-Carve Electronics"
+grabcad_name1: "X-Carve Electronics"
 grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/153599"
 ---
 
@@ -140,28 +140,28 @@ Now for some wiring. Strip about two inches from the end of one piece of stepper
 
 Strip the ends of the four wires about one quarter of an inch.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/707/original/1066.jpg?1424471887)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/707/original/1066.jpg?1424471887)
 
 <h3 id="determine-axes">
 4. Determine the Axes</h3>
 
 Now twist the copper from the black and green wires together. This will make the stepper motor that the cable is attached to resist movement.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/712/original/1069.jpg?1424475157)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/712/original/1069.jpg?1424475157)
 
 Gently push the X-Axis of your machine in one direction, if the motor feels like it's resisting your efforts you've identified that piece of stepper cable as "X."
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/713/original/1072.jpg?1424475158)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/713/original/1072.jpg?1424475158)
 
 If you don't feel resistance try moving the Y and Z axes until you find the motor that is resisting movement. If you're unsure whether or not you're encountering resistance try untwisting the green and black wires and comparing resistance.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/714/original/1074.jpg?1424475160)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/714/original/1074.jpg?1424475160)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/715/original/1075.jpg?1424475161)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/715/original/1075.jpg?1424475161)
 
 Label the stepper cable as you go.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/716/original/1079.jpg?1424475162)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/716/original/1079.jpg?1424475162)
 
 <h3 id="solder-pins">
 5. Solder Pins to gShield</h3>
@@ -206,11 +206,11 @@ Place the pins into the gShield making sure that the black plastic touches the t
 
 Once you've determined which stepper cable belongs to which axis you can wire them into the gShield. First loosen all of the screws on the gShield (they will jump a thread when they are fully loose, but they won't come out of the terminal blocks.)
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/717/original/1082.jpg?1424475163)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/717/original/1082.jpg?1424475163)
 
 The gShield is marked "X," "Y," and "Z." Wire the stepper cable according to the markings on the shield and order your wires (from left to right) <span style="color:black">**black**</span>, <span style="color:green">**green**</span>, **white**, <span style="color:red">**red**</span>.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/718/original/1096.jpg?1424475165)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/718/original/1096.jpg?1424475165)
 
 Check out this diagram for clarification.
 
@@ -247,11 +247,11 @@ Check out this diagram for clarification.
 
 Now grab your Arduino and mount it in the gShield Enclosure. You'll use three of its four mounting holes to do so.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/729/original/Electronics%20Arduino%20Mounting%20Holes.png?1424475991)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/729/original/Electronics%20Arduino%20Mounting%20Holes.png?1424475991)
 
 Push the USB port through the square hole on the gShield enclosure and line up the screws with the threaded inserts on the gShield Enclosure. Screw the Arduino down to the enclosure remembering to alternate screws as you tighten to keep the board even. There's no reason to go past finger tight with these.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/721/original/1107.jpg?1424475530)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/721/original/1107.jpg?1424475530)
 
 <div class="note">
 <i class="fa fa-hand-o-right"></i>
@@ -286,7 +286,7 @@ Push the USB port through the square hole on the gShield enclosure and line up t
 
 Now push the gShield onto the Arduino. There are pins on the gShield that go into the headers of the Arduino. Route the stepper cables out of the three square holes as you do this.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/722/original/1117.jpg?1424475531)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/722/original/1117.jpg?1424475531)
 
 <h3 id="power-gshield">
 9. Power the gShield and 24V Fan</h3>
@@ -338,11 +338,11 @@ Now strip the zip wire on one end and strip the 24V fan's wires. Twist the <span
 
 Loosen the screws in the power terminal of the gShield and insert the <span style="color:red">red</span> twisted pair into Vmot and the <span style="color:black">black</span> twisted pair into Gnd.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/727/original/1129.jpg?1424475663)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/727/original/1129.jpg?1424475663)
 
 Strip the other end of the zip wire and insert the ends into the large green terminal on the Power Supply Interface.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/728/original/1134.jpg?1424475664)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/728/original/1134.jpg?1424475664)
 
 <h3 id="power-spindle">
 10. Power the 24V Spindle</h3>
@@ -390,11 +390,11 @@ Strip the zip wire from your spindle and put the ends into the remaining spots o
 
 Place the top of the gShield enclosure on to the bottom.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/878/original/1141.jpg?1427991581)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/878/original/1141.jpg?1427991581)
 
 There are two M3 x 6mm screws that couple the top and bottom. Thread them into the enclosure by hand and tighten them just past finger tight with your wrench.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/877/original/1143.jpg?1427991580)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/877/original/1143.jpg?1427991580)
 
 <h3 id="install-fan">
 12. Install the 24V Fan</h3>
@@ -422,7 +422,7 @@ There are two M3 x 6mm screws that couple the top and bottom. Thread them into t
 
 Use the four M3 x 35mm screws to attach the 24V fan to the gShield enclosure. <strong>The bag containing this hardware may be mislabeled as M3 x 25mm screws, but they are the correct 35mm length and should work without a problem.</strong>
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/879/original/1148.jpg?1427991781)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/879/original/1148.jpg?1427991781)
 
 <h3 id="connect-pwm">
 13. Connect PWM Spindle Control</h3>
@@ -546,7 +546,7 @@ Now is a good time to add the "actuators" for the limit switches. Start with the
 
 Repeat the process with the Y-Axis limit switch actuator on the left piece of Y-Axis Makerslide.
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/901/original/1246.jpg?1428001827)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/901/original/1246.jpg?1428001827)
 
 <h3 id="plug-in-assembly">
 15. Plug in the Electronics Assembly</h3>
@@ -569,4 +569,4 @@ Repeat the process with the Y-Axis limit switch actuator on the left piece of Y-
 
 Now it's time to plug your Power Supply Assembly into the wall. Make sure both switches on the interface are set to off and double check all of your wiring (especially the placement of red and black wires). If you've wired everything correctly, the blue lights on the gShield should light up!
 
- ![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/892/original/1274.jpg?1428000007)
+![](https://dzevsq2emy08i.cloudfront.net/paperclip/project_instruction_image_uploaded_images/892/original/1274.jpg?1428000007)

--- a/xcarve2015/step14/index.md
+++ b/xcarve2015/step14/index.md
@@ -5,11 +5,11 @@ time_estimate: 45
 category: step
 step_number: 14
 permalink: /xcarve2015/step14/
-next-step: /xcarve2015/step15/
+next_step: /xcarve2015/step15/
 redirect_from: "/step14/"
-next-step-title: "Calibrate"
+next_step_title: "Calibrate"
 grabcad_name1: "X-Carve Electronics"
-grabcad-url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/153599"
+grabcad_url1: "https://workbench.grabcad.com/workbench/projects/gcl5zpCuwqCXWLvYktLQBc-2IHvossNo37ycTOkzg6gREW#/space/gcvs_XeRNVzNkfG_tFTAMd0C2lBbCsLcagOxXb1Jlki0kT/link/153599"
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/6DkhEQ8LhYA" frameborder="0" allowfullscreen>

--- a/xcarve2015/step15/index.md
+++ b/xcarve2015/step15/index.md
@@ -1,9 +1,9 @@
 ---
 layout: xcarve2015
-title:  "Calibrate"
-time-estimate: 15
+title: "Calibrate"
+time_estimate: 15
 category: step
-step-number: 15
+step_number: 15
 permalink: /xcarve2015/step15/
 next-step: /xcarve2015/step16/
 redirect_from: "/step15/"
@@ -17,7 +17,7 @@ next-step-title: "Install Drivers"
 
 Check out this tuning video to make sure you've got everything assembled and working the way it should.
 
-The video will guide you through squaring your machine, adjusting the v-wheels and adjusting the eccentric nuts.  Check out this animation to help better understand the motion of the eccentric nuts and v-wheels.
+The video will guide you through squaring your machine, adjusting the v-wheels and adjusting the eccentric nuts. Check out this animation to help better understand the motion of the eccentric nuts and v-wheels.
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/nX0J317l0mY" frameborder="0" allowfullscreen></iframe>
 

--- a/xcarve2015/step15/index.md
+++ b/xcarve2015/step15/index.md
@@ -5,9 +5,9 @@ time_estimate: 15
 category: step
 step_number: 15
 permalink: /xcarve2015/step15/
-next-step: /xcarve2015/step16/
+next_step: /xcarve2015/step16/
 redirect_from: "/step15/"
-next-step-title: "Install Drivers"
+next_step_title: "Install Drivers"
 ---
 
 <iframe width="560" height="315" src="https://www.youtube.com/embed/5AwuLbbvZNQ" frameborder="0" allowfullscreen>

--- a/xcarve2015/step17/index.md
+++ b/xcarve2015/step17/index.md
@@ -5,9 +5,9 @@ time_estimate: 5
 category: step
 step_number: 17
 permalink: /xcarve2015/step17/
-next-step: /xcarve2015/step18/
+next_step: /xcarve2015/step18/
 redirect_from: "/step17/"
-next-step-title: "Get Carving!"
+next_step_title: "Get Carving!"
 ---
 
 Easel, our super easy-to-use web app, will help you get your machine and electronics working.

--- a/xcarve2015/step17/index.md
+++ b/xcarve2015/step17/index.md
@@ -1,9 +1,9 @@
 ---
 layout: xcarve2015
-title:  "Machine Setup"
-time-estimate: 5
+title: "Machine Setup"
+time_estimate: 5
 category: step
-step-number: 17
+step_number: 17
 permalink: /xcarve2015/step17/
 next-step: /xcarve2015/step18/
 redirect_from: "/step17/"

--- a/xcarve2015/step18/index.md
+++ b/xcarve2015/step18/index.md
@@ -2,7 +2,7 @@
 layout: xcarve2015
 title:  "Get Carving!"
 category: step
-step-number: 18
+step_number: 18
 permalink: /xcarve2015/step18/
 ---
 


### PR DESCRIPTION
- Fixed error
`Liquid Warning: Liquid syntax error (line 23): Expected end_of_string but found dash in "{{ page.step - number }}" in /_layouts/xcarve2015.html`
- Upgrade Bootstrap to most current version.. No breaking changes (https://getbootstrap.com/docs/4.0/migration/#stable-changes)