### PR TITLE
Sidebar Navbar Instructions

### DIFF
--- a/1000mm/index.md
+++ b/1000mm/index.md
@@ -234,7 +234,7 @@ If you purchased a tool kit with your machine, most of these should be included 
   </div>
   <div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
     <div class="panel panel-default">
-      <div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
+      <div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF;border:1px solid #ddd;" class="panel-heading" role="tab" id="rail-size-header">
         <h4 class="panel-title">
           <strong>Rail Size</strong>
         </h4>

--- a/500mm/index.md
+++ b/500mm/index.md
@@ -234,7 +234,7 @@ If you purchased a tool kit with your machine, most of these should be included 
    </div>
    <div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
       <div class="panel panel-default">
-         <div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
+         <div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF;border:1px solid #ddd;" class="panel-heading" role="tab" id="rail-size-header">
             <h4 class="panel-title">
                <strong>Rail Size</strong>
             </h4>

--- a/750mm/index.md
+++ b/750mm/index.md
@@ -240,7 +240,7 @@ If you purchased a tool kit with your machine, most of these should be included 
 	</div>
 	<div class="panel-group" id="rail-size-accordion" role="tablist" aria-multiselectable="true">
 		<div class="panel panel-default">
-			<div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF" class="panel-heading" role="tab" id="rail-size-header">
+			<div data-toggle="collapse" data-parent="#rail-size-accordion" href="#rail-size" aria-expanded="false" aria-controls="rail-size" style="color:#000;background:#FFFFFF;border:1px solid #ddd;" class="panel-heading" role="tab" id="rail-size-header">
 				<h4 class="panel-title">
 					<strong>Rail Size</strong>
 				</h4>

--- a/_config.yml
+++ b/_config.yml
@@ -1,12 +1,8 @@
-# Site settings
-baseurl: ""
-url: "http://x-carve-instructions.inventables.com" # the base hostname & protocol for your site
-
 # Build settings
 markdown: kramdown
 
 plugins:
-- jekyll-redirect-from
-- jekyll-textile-converter
-- github-pages
-- octopress-autoprefixer
+  - jekyll-redirect-from
+  - jekyll-textile-converter
+  - github-pages
+  - octopress-autoprefixer

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,31 +1,32 @@
 <head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-  <title>X-Carve Instructions: {% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
+    <title>X-Carve Instructions: {% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
 
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}" />
+    <link rel="icon" href="{{ "/favicon.ico" | prepend: site.baseurl }}" />
 
-  <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" type="text/css" data-noprefix="">
-  <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" type="text/css"
+        data-noprefix="">
+    <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/css/bootstrap.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-  <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
-  <!-- Hotjar Tracking Code for x-carve-instructions.inventables.com -->
-<script>
-    (function(h,o,t,j,a,r){
-        h.hj=h.hj||function(){(h.hj.q=h.hj.q||[]).push(arguments)};
-        h._hjSettings={hjid:93027,hjsv:5};
-        a=o.getElementsByTagName('head')[0];
-        r=o.createElement('script');r.async=1;
-        r.src=t+h._hjSettings.hjid+j+h._hjSettings.hjsv;
-        a.appendChild(r);
-    })(window,document,'//static.hotjar.com/c/hotjar-','.js?sv=');
-</script>
+    <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
+    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
+    <!-- Hotjar Tracking Code for x-carve-instructions.inventables.com -->
+    <script>
+        (function (h, o, t, j, a, r) {
+            h.hj = h.hj || function () { (h.hj.q = h.hj.q || []).push(arguments) };
+            h._hjSettings = { hjid: 93027, hjsv: 5 };
+            a = o.getElementsByTagName('head')[0];
+            r = o.createElement('script'); r.async = 1;
+            r.src = t + h._hjSettings.hjid + j + h._hjSettings.hjsv;
+            a.appendChild(r);
+        })(window, document, '//static.hotjar.com/c/hotjar-', '.js?sv=');
+    </script>
 
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,38 +1,57 @@
 <div class="inventables-navbar-container" id="inventables-nav-outer">
   <div class="container">
     <nav class="navbar navbar-expand-lg">
-      <ul class="nav nav-pills pull-left top-nav">
-        <li>
-          <a href="https://www.inventables.com" data-auto-route="true">
-            <img
-              id="site-logo"
-              class="logo-big"
-              src="https://d2rhdy377k7eul.cloudfront.net/assets/shared/rebranding-inventables-logo-3007d3ef0bd3650e6dd865dfc8c3d211.svg"
-              alt="Inventables"
-            />
-          </a>
-        </li>
-      </ul>
-      <ul class="nav navbar-nav nav-pills ml-auto" id="flagship-nav">
-        <li>
-          <a href="https://www.inventables.com/technologies/x-carve">X-Carve</a>
-        </li>
-        <li>
-          <a href="https://www.inventables.com/technologies/carvey">Carvey</a>
-        </li>
-        <li>
-          <a href="https://www.inventables.com/technologies/easel">Easel</a>
-        </li>
-        <li><a href="https://www.inventables.com/projects">Projects</a></li>
-        <li><a href="https://www.inventables.com/forum">Forum</a></li>
-        <li><a href="https://inventables.desk.com">Support</a></li>
-        <li>
-          <a
-            href="https://github.com/inventables/x-carve-instructions"
-            class="github-link"
-            ><i class="fa fa-code-fork"></i>Contribute to these instructions!</a
-          >
-        </li>
+      <a
+        class="nav nav-pills pull-left navbar-brand top-nav"
+        href="https://www.inventables.com"
+        data-auto-route="true"
+      >
+        <img
+          id="site-logo"
+          class="logo-big"
+          src="https://d2rhdy377k7eul.cloudfront.net/assets/shared/rebranding-inventables-logo-3007d3ef0bd3650e6dd865dfc8c3d211.svg"
+          alt="Inventables"
+        />
+      </a>
+
+      <ul
+        class="nav navbar-nav nav-pills navbar-light ml-auto"
+        id="flagship-nav"
+      >
+        <button
+          class="navbar-toggler"
+          type="button"
+          data-toggle="collapse"
+          data-target="#navbarSupportedContent"
+          aria-controls="navbarSupportedContent"
+          aria-expanded="false"
+          aria-label="Toggle navigation"
+        >
+          <span class="navbar-toggler-icon"></span>
+        </button>
+        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+          <li>
+            <a href="https://www.inventables.com/technologies/x-carve"
+              >X-Carve</a
+            >
+          </li>
+          <li>
+            <a href="https://www.inventables.com/technologies/carvey">Carvey</a>
+          </li>
+          <li>
+            <a href="https://www.inventables.com/technologies/easel">Easel</a>
+          </li>
+          <li><a href="https://www.inventables.com/projects">Projects</a></li>
+          <li><a href="https://www.inventables.com/forum">Forum</a></li>
+          <li><a href="https://inventables.desk.com">Support</a></li>
+          <li>
+            <a
+              href="https://github.com/inventables/x-carve-instructions"
+              class="github-link"
+              ><i class="fa fa-github"></i>Help contribute!</a
+            >
+          </li>
+        </div>
       </ul>
     </nav>
   </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,39 +1,19 @@
 <div class="inventables-navbar-container" id="inventables-nav-outer">
   <div class="container">
-    <nav class="navbar navbar-expand-lg">
-      <a
-        class="nav nav-pills pull-left navbar-brand top-nav"
-        href="https://www.inventables.com"
-        data-auto-route="true"
-      >
-        <img
-          id="site-logo"
-          class="logo-big"
-          src="https://d2rhdy377k7eul.cloudfront.net/assets/shared/rebranding-inventables-logo-3007d3ef0bd3650e6dd865dfc8c3d211.svg"
-          alt="Inventables"
-        />
+    <nav class="navbar navbar-expand-lg navbar-light">
+      <a class="nav nav-pills pull-left navbar-brand top-nav" href="https://www.inventables.com" data-auto-route="true">
+        <img id="site-logo" class="logo-big" src="https://d2rhdy377k7eul.cloudfront.net/assets/shared/rebranding-inventables-logo-3007d3ef0bd3650e6dd865dfc8c3d211.svg"
+          alt="Inventables" />
       </a>
 
-      <ul
-        class="nav navbar-nav nav-pills navbar-light ml-auto"
-        id="flagship-nav"
-      >
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-toggle="collapse"
-          data-target="#navbarSupportedContent"
-          aria-controls="navbarSupportedContent"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse" id="navbarSupportedContent">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+        aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+      <div class="collapse navbar-collapse" id="navbarSupportedContent">
+        <ul class="nav navbar-nav nav-pills ml-auto" id="flagship-nav">
           <li>
-            <a href="https://www.inventables.com/technologies/x-carve"
-              >X-Carve</a
-            >
+            <a href="https://www.inventables.com/technologies/x-carve">X-Carve</a>
           </li>
           <li>
             <a href="https://www.inventables.com/technologies/carvey">Carvey</a>
@@ -44,15 +24,25 @@
           <li><a href="https://www.inventables.com/projects">Projects</a></li>
           <li><a href="https://www.inventables.com/forum">Forum</a></li>
           <li><a href="https://inventables.desk.com">Support</a></li>
-          <li>
+          <!-- <li>
             <a
               href="https://github.com/inventables/x-carve-instructions"
               class="github-link"
               ><i class="fa fa-github"></i>Help contribute!</a
             >
-          </li>
-        </div>
-      </ul>
+          </li> -->
+        </ul>
+      </div>
     </nav>
   </div>
 </div>
+<a href="https://github.com/inventables/x-carve-instructions" class="github-corner" aria-label="View source on GitHub">
+  <svg width="80" height="80" viewBox="0 0 250 250" style="fill:#ffa400; color:#fff; position: absolute; top: -5px; border: 0; right: 0;"
+    aria-hidden="true">
+    <path d="M0,0 L115,115 L130,115 L142,142 L250,250 L250,0 Z"></path>
+    <path d="M128.3,109.0 C113.8,99.7 119.0,89.6 119.0,89.6 C122.0,82.7 120.5,78.6 120.5,78.6 C119.2,72.0 123.4,76.3 123.4,76.3 C127.3,80.9 125.5,87.3 125.5,87.3 C122.9,97.6 130.6,101.9 134.4,103.2"
+      fill="currentColor" style="transform-origin: 130px 106px;" class="octo-arm"></path>
+    <path d="M115.0,115.0 C114.9,115.1 118.7,116.5 119.8,115.4 L133.7,101.6 C136.9,99.2 139.9,98.4 142.2,98.6 C133.8,88.0 127.5,74.4 143.8,58.0 C148.5,53.4 154.0,51.2 159.7,51.0 C160.3,49.4 163.2,43.6 171.4,40.1 C171.4,40.1 176.1,42.5 178.8,56.2 C183.1,58.6 187.2,61.8 190.9,65.4 C194.5,69.0 197.7,73.2 200.1,77.6 C213.8,80.2 216.3,84.9 216.3,84.9 C212.7,93.1 206.9,96.0 205.4,96.6 C205.1,102.4 203.0,107.8 198.3,112.5 C181.9,128.9 168.3,122.5 157.7,114.1 C157.9,116.9 156.7,120.9 152.7,124.9 L141.0,136.5 C139.8,137.7 141.6,141.9 141.8,141.8 Z"
+      fill="currentColor" class="octo-body"></path>
+  </svg>
+</a>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,7 +12,7 @@
         <span class="navbar-toggler-icon"></span>
       </button>
       <div class="collapse navbar-collapse" id="navbarSupportedContent">
-        <ul class="nav navbar-nav nav-pills ml-auto" id="flagship-nav">
+        <ul class="nav navbar-nav nav-pills" id="flagship-nav">
           <li>
             <a href="https://www.inventables.com/technologies/x-carve">X-Carve</a>
           </li>

--- a/_includes/stepnav1000mm.html
+++ b/_includes/stepnav1000mm.html
@@ -1,20 +1,25 @@
 <ul>
   <li><a href="{{ site.baseurl }}/1000mm/">Welcome!</a></li>
   {% for item in site.data.navigation.stepnav %}
-  <li class="nav-item {% if page.parent == item.title %}active{% endif %}">
+  <li
+    class="nav-item dropdown show{% if page.parent == item.title %}active{% endif %}"
+  >
     {% if item.subnav %}
-      <a href="#" id="step-drop-btn" data-toggle="dropdown">{{ item.title }}
-        &nbsp;<i class="fa fa-caret-down"></i></a>
-      <ol class="nav step-nav dropdown-menu" aria-labelledby="step-drop-btn">
-        {% for subitem in item.subnav %}
-          <a href="/1000mm{{ subitem.url | prepend: item.url }}">
-            <li>{{ subitem.title }}</li>
-          </a>
-        {% endfor %}
-      </ol>
-    {% else %}
-      <a href="/1000mm{{ item.url }}">{{ item.title }}</a>
-    {% endif %}
+    <a
+      href="#"
+      id="step-drop-btn"
+      class="dropdown-toggle"
+      data-toggle="dropdown"
+      >{{ item.title }}</a
+    >
+    <ol class="step-nav dropdown-menu" aria-labelledby="step-drop-btn">
+      {% for subitem in item.subnav %}
+      <a href="/1000mm{{ subitem.url | prepend: item.url }}">
+        <li>{{ subitem.title }}</li>
+      </a>
+      {% endfor %}
+    </ol>
+    {% else %} <a href="/1000mm{{ item.url }}">{{ item.title }}</a> {% endif %}
   </li>
   {% endfor %}
 </ul>

--- a/_includes/stepnav500mm.html
+++ b/_includes/stepnav500mm.html
@@ -1,20 +1,25 @@
 <ul>
   <li><a href="{{ site.baseurl }}/500mm/">Welcome!</a></li>
   {% for item in site.data.navigation.stepnav %}
-  <li class="nav-item {% if page.parent == item.title %}active{% endif %}">
+  <li
+    class="nav-item dropdown show{% if page.parent == item.title %}active{% endif %}"
+  >
     {% if item.subnav %}
-      <a href="#" id="step-drop-btn" data-toggle="dropdown">{{ item.title }}
-        &nbsp;<i class="fa fa-caret-down"></i></a>
-      <ol class="nav step-nav dropdown-menu" aria-labelledby="step-drop-btn">
-        {% for subitem in item.subnav %}
-          <a href="/500mm{{ subitem.url | prepend: item.url }}">
-            <li>{{ subitem.title }}</li>
-          </a>
-        {% endfor %}
-      </ol>
-    {% else %}
-      <a href="/500mm{{ item.url }}">{{ item.title }}</a>
-    {% endif %}
+    <a
+      href="#"
+      id="step-drop-btn"
+      class="dropdown-toggle"
+      data-toggle="dropdown"
+      >{{ item.title }}</a
+    >
+    <ol class="step-nav dropdown-menu" aria-labelledby="step-drop-btn">
+      {% for subitem in item.subnav %}
+      <a href="/500mm{{ subitem.url | prepend: item.url }}">
+        <li>{{ subitem.title }}</li>
+      </a>
+      {% endfor %}
+    </ol>
+    {% else %} <a href="/500mm{{ item.url }}">{{ item.title }}</a> {% endif %}
   </li>
   {% endfor %}
 </ul>

--- a/_includes/stepnav750mm.html
+++ b/_includes/stepnav750mm.html
@@ -1,20 +1,25 @@
 <ul>
   <li><a href="{{ site.baseurl }}/750mm/">Welcome!</a></li>
   {% for item in site.data.navigation.stepnav %}
-  <li class="nav-item {% if page.parent == item.title %}active{% endif %}">
+  <li
+    class="nav-item dropdown show{% if page.parent == item.title %}active{% endif %}"
+  >
     {% if item.subnav %}
-      <a href="#" id="step-drop-btn" data-toggle="dropdown">{{ item.title }}
-        &nbsp;<i class="fa fa-caret-down"></i></a>
-      <ol class="nav step-nav dropdown-menu" aria-labelledby="step-drop-btn">
-        {% for subitem in item.subnav %}
-          <a href="/750mm{{ subitem.url | prepend: item.url }}">
-            <li>{{ subitem.title }}</li>
-          </a>
-        {% endfor %}
-      </ol>
-    {% else %}
-      <a href="/750mm{{ item.url }}">{{ item.title }}</a>
-    {% endif %}
+    <a
+      href="#"
+      id="step-drop-btn"
+      class="dropdown-toggle"
+      data-toggle="dropdown"
+      >{{ item.title }}</a
+    >
+    <ol class="step-nav dropdown-menu" aria-labelledby="step-drop-btn">
+      {% for subitem in item.subnav %}
+      <a href="/750mm{{ subitem.url | prepend: item.url }}">
+        <li>{{ subitem.title }}</li>
+      </a>
+      {% endfor %}
+    </ol>
+    {% else %} <a href="/750mm{{ item.url }}">{{ item.title }}</a> {% endif %}
   </li>
   {% endfor %}
 </ul>

--- a/_includes/stepsidebar1000mm.html
+++ b/_includes/stepsidebar1000mm.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light">
+<nav class="navbar navbar-expand-md navbar-light">
   <a class="navbar-brand instructions-menu-label" href="#">Instructions</a>
   <button
     class="navbar-toggler"

--- a/_includes/stepsidebar1000mm.html
+++ b/_includes/stepsidebar1000mm.html
@@ -1,0 +1,41 @@
+<nav class="navbar navbar-expand-lg navbar-light">
+  <button
+    class="navbar-toggler"
+    type="button"
+    data-toggle="collapse"
+    data-target="#navbarTogglerDemo02"
+    aria-controls="navbarTogglerDemo02"
+    aria-expanded="false"
+    aria-label="Toggle navigation"
+  >
+    <span class="navbar-toggler-icon"></span>
+  </button>
+  <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
+    <ul class="sidebar">
+      <li><a href="{{ site.baseurl }}/1000mm/">Welcome!</a></li>
+      {% for item in site.data.navigation.stepnav %}
+      <li class="nav-item">
+        {% if item.subnav %}
+        <a href="#{{item.step}}" id="step-drop-btn" {% if page.parent == item.title %}class="active"{% endif %} data-toggle="collapse"
+          >{{ item.title }} &nbsp;<i class="fa fa-caret-down"></i
+        ></a>
+        <ol
+          class="collapse {% if page.parent == item.title %}show{% endif %}"
+          id="{{item.step}}"
+        >
+          {% for subitem in item.subnav %}
+            {% assign url = subitem.url | prepend: item.url | prepend: "/1000mm" %}
+          <a
+            {% if page.url == url %}class="active"{% endif %}
+            href={{url}}
+          >
+            <li>{{ subitem.title }}</li>
+          </a>
+          {% endfor %}
+        </ol>
+        {% else %} <a href="/1000mm{{ item.url }}">{{ item.title }}</a> {% endif %}
+      </li>
+      {% endfor %}
+    </ul>
+  </div>
+</nav>

--- a/_includes/stepsidebar1000mm.html
+++ b/_includes/stepsidebar1000mm.html
@@ -1,4 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light">
+  <a class="navbar-brand instructions-menu-label" href="#">Instructions</a>
   <button
     class="navbar-toggler"
     type="button"
@@ -14,16 +15,16 @@
     <ul class="sidebar">
       <li class="nav-item"><a href="{{ site.baseurl }}/1000mm/" {% if page.url == '/1000mm/' %}class="active"{% endif %}>Welcome!</a></li>
       {% for item in site.data.navigation.stepnav %}
-      <li class="nav-item">
-        {% if item.subnav %}
-        <a href="#{{item.step}}" id="step-drop-btn" {% if page.parent == item.title %}class="active"{% endif %} data-toggle="collapse">
+      <li class="nav-item {% if page.parent == item.title %}active{% endif %}">
+          {% if item.subnav %}
+          <a href="#{{item.step}}" id="step-drop-btn" data-toggle="collapse">
           {{ item.title }} &nbsp;<i class="fa fa-caret-down"></i>
         </a>
         <ol class="collapse {% if page.parent == item.title %}show{% endif %}" id="{{item.step}}">
           {% for subitem in item.subnav %}
             {% assign url = subitem.url | prepend: item.url | prepend: "/1000mm" %}
           <a href={{url}} {% if page.url == url %}class="active"{% endif %}>
-            <li>{{ subitem.title }}</li>
+            <li class="subnav-item">{{ subitem.title }}</li>
           </a>
           {% endfor %}
         </ol>

--- a/_includes/stepsidebar500mm.html
+++ b/_includes/stepsidebar500mm.html
@@ -12,7 +12,7 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
     <ul class="sidebar">
-      <li class="nav-item"><a href="{{ site.baseurl }}/1000mm/" {% if page.url == '/1000mm/' %}class="active"{% endif %}>Welcome!</a></li>
+      <li class="nav-item"><a href="{{ site.baseurl }}/500mm/" {% if page.url == '/500mm/' %}class="active"{% endif %}>Welcome!</a></li>
       {% for item in site.data.navigation.stepnav %}
       <li class="nav-item">
         {% if item.subnav %}
@@ -21,15 +21,15 @@
         </a>
         <ol class="collapse {% if page.parent == item.title %}show{% endif %}" id="{{item.step}}">
           {% for subitem in item.subnav %}
-            {% assign url = subitem.url | prepend: item.url | prepend: "/1000mm" %}
+            {% assign url = subitem.url | prepend: item.url | prepend: "/500mm" %}
           <a href={{url}} {% if page.url == url %}class="active"{% endif %}>
             <li>{{ subitem.title }}</li>
           </a>
           {% endfor %}
         </ol>
         {% else %}
-          {% assign url = item.url | prepend: "/1000mm" %}
-          <a {% if page.url == url %}class="active"{% endif %} href="/1000mm{{ item.url }}">{{ item.title }}</a> 
+          {% assign url = item.url | prepend: "/500mm" %}
+          <a {% if page.url == url %}class="active"{% endif %} href="/500mm{{ item.url }}">{{ item.title }}</a>
         {% endif %}
       </li>
       {% endfor %}

--- a/_includes/stepsidebar500mm.html
+++ b/_includes/stepsidebar500mm.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light">
+<nav class="navbar navbar-expand-md navbar-light">
   <a class="navbar-brand instructions-menu-label" href="#">Instructions</a>
   <button
     class="navbar-toggler"

--- a/_includes/stepsidebar500mm.html
+++ b/_includes/stepsidebar500mm.html
@@ -1,4 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light">
+  <a class="navbar-brand instructions-menu-label" href="#">Instructions</a>
   <button
     class="navbar-toggler"
     type="button"
@@ -14,16 +15,16 @@
     <ul class="sidebar">
       <li class="nav-item"><a href="{{ site.baseurl }}/500mm/" {% if page.url == '/500mm/' %}class="active"{% endif %}>Welcome!</a></li>
       {% for item in site.data.navigation.stepnav %}
-      <li class="nav-item">
+      <li class="nav-item {% if page.parent == item.title %}active{% endif %}">
         {% if item.subnav %}
-        <a href="#{{item.step}}" id="step-drop-btn" {% if page.parent == item.title %}class="active"{% endif %} data-toggle="collapse">
+        <a href="#{{item.step}}" id="step-drop-btn" data-toggle="collapse">
           {{ item.title }} &nbsp;<i class="fa fa-caret-down"></i>
         </a>
         <ol class="collapse {% if page.parent == item.title %}show{% endif %}" id="{{item.step}}">
           {% for subitem in item.subnav %}
             {% assign url = subitem.url | prepend: item.url | prepend: "/500mm" %}
           <a href={{url}} {% if page.url == url %}class="active"{% endif %}>
-            <li>{{ subitem.title }}</li>
+            <li class="subnav-item">{{ subitem.title }}</li>
           </a>
           {% endfor %}
         </ol>

--- a/_includes/stepsidebar750mm.html
+++ b/_includes/stepsidebar750mm.html
@@ -1,4 +1,5 @@
 <nav class="navbar navbar-expand-lg navbar-light">
+  <a class="navbar-brand instructions-menu-label" href="#">Instructions</a>
   <button
     class="navbar-toggler"
     type="button"
@@ -14,16 +15,16 @@
     <ul class="sidebar">
       <li class="nav-item"><a href="{{ site.baseurl }}/750mm/" {% if page.url == '/750mm/' %}class="active"{% endif %}>Welcome!</a></li>
       {% for item in site.data.navigation.stepnav %}
-      <li class="nav-item">
-        {% if item.subnav %}
-        <a href="#{{item.step}}" id="step-drop-btn" {% if page.parent == item.title %}class="active"{% endif %} data-toggle="collapse">
+      <li class="nav-item {% if page.parent == item.title %}active{% endif %}">
+          {% if item.subnav %}
+          <a href="#{{item.step}}" id="step-drop-btn" data-toggle="collapse">
           {{ item.title }} &nbsp;<i class="fa fa-caret-down"></i>
         </a>
         <ol class="collapse {% if page.parent == item.title %}show{% endif %}" id="{{item.step}}">
           {% for subitem in item.subnav %}
             {% assign url = subitem.url | prepend: item.url | prepend: "/750mm" %}
           <a href={{url}} {% if page.url == url %}class="active"{% endif %}>
-            <li>{{ subitem.title }}</li>
+            <li class="subnav-item">{{ subitem.title }}</li>
           </a>
           {% endfor %}
         </ol>

--- a/_includes/stepsidebar750mm.html
+++ b/_includes/stepsidebar750mm.html
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg navbar-light">
+<nav class="navbar navbar-expand-md navbar-light">
   <a class="navbar-brand instructions-menu-label" href="#">Instructions</a>
   <button
     class="navbar-toggler"

--- a/_includes/stepsidebar750mm.html
+++ b/_includes/stepsidebar750mm.html
@@ -12,7 +12,7 @@
   </button>
   <div class="collapse navbar-collapse" id="navbarTogglerDemo02">
     <ul class="sidebar">
-      <li class="nav-item"><a href="{{ site.baseurl }}/1000mm/" {% if page.url == '/1000mm/' %}class="active"{% endif %}>Welcome!</a></li>
+      <li class="nav-item"><a href="{{ site.baseurl }}/750mm/" {% if page.url == '/750mm/' %}class="active"{% endif %}>Welcome!</a></li>
       {% for item in site.data.navigation.stepnav %}
       <li class="nav-item">
         {% if item.subnav %}
@@ -21,15 +21,15 @@
         </a>
         <ol class="collapse {% if page.parent == item.title %}show{% endif %}" id="{{item.step}}">
           {% for subitem in item.subnav %}
-            {% assign url = subitem.url | prepend: item.url | prepend: "/1000mm" %}
+            {% assign url = subitem.url | prepend: item.url | prepend: "/750mm" %}
           <a href={{url}} {% if page.url == url %}class="active"{% endif %}>
             <li>{{ subitem.title }}</li>
           </a>
           {% endfor %}
         </ol>
-        {% else %}
-          {% assign url = item.url | prepend: "/1000mm" %}
-          <a {% if page.url == url %}class="active"{% endif %} href="/1000mm{{ item.url }}">{{ item.title }}</a> 
+        {% else %} 
+          {% assign url = item.url | prepend: "/750mm" %}
+          <a {% if page.url == url %}class="active"{% endif %} href="/750mm{{ item.url }}">{{ item.title }}</a>
         {% endif %}
       </li>
       {% endfor %}

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -13,17 +13,17 @@
         <header class="post-header">
           <div class="instruction-breadcrumbs">
             <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
-            <a href="{{ site.baseurl }}/1000mm/">1000mm</a> 
-            {% if page.parent%} 
-              &#47; {{ page.parent }} 
-            {% endif %} 
+            <a href="{{ site.baseurl }}/1000mm/">1000mm</a>
+            {% if page.parent%}
+            &#47; {{ page.parent }}
+            {% endif %}
             &#47;
             <span class="current-page">
               {% if page.title %} {{ page.title }} {% endif %}
             </span>
           </div>
           <h1 class="step-title">{{ page.title }}</h1>
-          
+
           {% if page.time_estimate %}
           <div class="time-estimate">
             <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
@@ -31,12 +31,12 @@
           {% endif %}
 
           {% if page.grabcad_url1 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
-              <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
-            </a>
-            {% if page.z-axis == true %}
-            <span class="grabcad-note">(You're only building part of this now)</span>
-            {% endif %}
+          <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
+            <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
+          </a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
           {% endif %}
 
           {% if page.grabcad_url2 %}
@@ -52,7 +52,7 @@
         </div>
 
       </div>
-      <div class="col-md-4">
+      <div class="col-md-4 col-md-4">
         <div class="page-diagram">
           {% if page.diagram %}
           <img src="{{ page.diagram | prepend: site.baseurl }}" />

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -15,7 +15,7 @@
         >
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
+              <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
               <a href="{{ site.baseurl }}/1000mm/">1000mm</a> {% if
               page.parent%} &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -10,15 +10,14 @@
         <div id="off-canvas-sidebar" class="col-md-2">
           {% include stepsidebar1000mm.html %}
         </div>
-
         <div
           class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
         >
           <header class="post-header">
             <div class="instruction-breadcrumbs">
               <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
-              <a href="{{ site.baseurl }}/1000mm/">1000mm</a> {% if page.parent
-              %} &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{ site.baseurl }}/1000mm/">1000mm</a> {% if
+              page.parent%} &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">
                 {% if page.title %} {{ page.title }} {% endif %}
               </span>

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -1,64 +1,70 @@
 <!DOCTYPE html>
 <html>
-  {% include head.html %}
+{% include head.html %}
 
-  <body data-spy="scroll" data-target="#subnav">
-    {% include header.html %}
+<body data-spy="scroll" data-target="#subnav">
+  {% include header.html %}
+  <div class="instructions-wrapper container-fluid">
+    <div class="row">
+      <div id="off-canvas-sidebar" class="col-md-2">
+        {% include stepsidebar1000mm.html %}
+      </div>
+      <div class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
+            <a href="{{ site.baseurl }}/1000mm/">1000mm</a> 
+            {% if page.parent%} 
+              &#47; {{ page.parent }} 
+            {% endif %} 
+            &#47;
+            <span class="current-page">
+              {% if page.title %} {{ page.title }} {% endif %}
+            </span>
+          </div>
+          <h1 class="step-title">{{ page.title }}</h1>
+          
+          {% if page.time_estimate %}
+          <div class="time-estimate">
+            <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+          </div>
+          {% endif %}
 
-    <div class="instructions-wrapper container-fluid">
-      <div class="row">
-        <div id="off-canvas-sidebar" class="col-md-2">
-          {% include stepsidebar1000mm.html %}
-        </div>
-        <div
-          class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
-        >
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
-              <a href="{{ site.baseurl }}/1000mm/">1000mm</a> {% if
-              page.parent%} &#47; {{ page.parent }} {% endif %} &#47;
-              <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %} {% if page.grabcad_url1 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url1 }}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z_axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad_url2 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url2 }}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+          {% if page.grabcad_url1 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
+              <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
+            </a>
+            {% if page.z-axis == true %}
+            <span class="grabcad-note">(You're only building part of this now)</span>
             {% endif %}
-          </header>
-          <div class="step-text">
-            {{ content }} {% include next-step.html %}
-          </div>
+          {% endif %}
+
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
+            <i class="fa fa-cube"></i> GrabCAD Model of
+            {{ page.grabcad_name2 }}
+          </a>
+          {% endif %}
+        </header>
+
+        <div class="step-text">
+          {{ content }} {% include next-step.html %}
         </div>
-        <div class="col-sm-5">
-          <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
-          </div>
+
+      </div>
+      <div class="col-md-4">
+        <div class="page-diagram">
+          {% if page.diagram %}
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
+          {% endif %}
+          {% if page.diagram2 %}
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
+          {% endif %}
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_layouts/default1000mm.html
+++ b/_layouts/default1000mm.html
@@ -1,73 +1,65 @@
 <!DOCTYPE html>
 <html>
+  {% include head.html %}
 
-{% include head.html %}
+  <body data-spy="scroll" data-target="#subnav">
+    {% include header.html %}
 
-<body data-spy="scroll" data-target="#subnav">
+    <div class="instructions-wrapper container-fluid">
+      <div class="row">
+        <div id="off-canvas-sidebar" class="col-md-2">
+          {% include stepsidebar1000mm.html %}
+        </div>
 
-  {% include header.html %}
+        <div
+          class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
+        >
+          <header class="post-header">
+            <div class="instruction-breadcrumbs">
+              <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
+              <a href="{{ site.baseurl }}/1000mm/">1000mm</a> {% if page.parent
+              %} &#47; {{ page.parent }} {% endif %} &#47;
+              <span class="current-page">
+                {% if page.title %} {{ page.title }} {% endif %}
+              </span>
+            </div>
+            <h1 class="step-title">{{ page.title }}</h1>
 
-  <div class="instructions-wrapper container">
-    <div id="off-canvas-sidebar">
-      {% include stepnav1000mm.html %}
-      <a id="close" href="#"><i class="fa fa-times"></i></a>
-    </div>
-    <div class="row topic-nav">
-      {% include stepnav1000mm.html %}
-    </div>
-    <div class="row">
-      <div class="page-content js-instruction-step col-sm-7">
-        <header class="post-header">
-          <div class="instruction-breadcrumbs">
-            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/1000mm/">1000mm</a>
-            {% if page.parent %}
-            &#47;
-            {{ page.parent }}
+            {% if page.time_estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad_url1 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url1 }}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z_axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad_url2 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url2 }}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-            &#47;
-            <span class="current-page">
-              {% if page.title %}
-              {{ page.title }}
-              {% endif %}
-            </span>
+          </header>
+          <div class="step-text">
+            {{ content }} {% include next-step.html %}
           </div>
-          <h1 class="step-title">{{ page.title }}</h1>
-
-          {% if page.time_estimate %}
-          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-          {% endif %}
-
-          {% if page.grabcad_url1 %}
-          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name1}}</a>
-          {% if page.z_axis == true %}
-          <span class="grabcad-note">(You're only building part of this now)</span>
-          {% endif %}
-          {% endif %}
-          {% if page.grabcad_url2 %}
-          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name2}}</a>
-          {% endif %}
-
-        </header>
-        <div class="step-text">
-          {{ content }}
-          {% include next-step.html %}
         </div>
-      </div>
-      <div class="col-sm-5">
-        <div class="page-diagram">
-          {% if page.diagram %}
-          <img src="{{ page.diagram | prepend: site.baseurl }}" />
-          {% endif %}
-          {% if page.diagram2 %}
-          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
-          {% endif %}
+        <div class="col-sm-5">
+          <div class="page-diagram">
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  {% include scripts.html %}
-</body>
-
+    {% include scripts.html %}
+  </body>
 </html>

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -1,61 +1,64 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-
   <body data-spy="scroll" data-target="#subnav">
     {% include header.html %}
-
     <div class="instructions-wrapper container-fluid">
       <div class="row">
         <div id="off-canvas-sidebar" class="col-md-2">
           {% include stepsidebar500mm.html %}
         </div>
-
-        <div
-          class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
-        >
+        <div class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3">
           <header class="post-header">
             <div class="instruction-breadcrumbs">
               <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
-              <a href="{{ site.baseurl }}/500mm/">500mm</a> {% if page.parent %}
-              &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{ site.baseurl }}/500mm/">500mm</a>
+              {% if page.parent%} 
+                &#47; {{ page.parent }} 
+              {% endif %} 
+              &#47;
               <span class="current-page">
                 {% if page.title %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time-estimate %}
+            
+            {% if page.time_estimate %}
             <div class="time-estimate">
               <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
             </div>
-            {% endif %} {% if page.grabcad_url1 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url1 }}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad_url2 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url2 }}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+            {% endif %}
+
+            {% if page.grabcad_url1 %}
+              <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
+                <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
+              </a>
+              {% if page.z-axis == true %}
+              <span class="grabcad-note">(You're only building part of this now)</span>
+              {% endif %}
+            {% endif %}
+
+            {% if page.grabcad_url2 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
+              <i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}
+            </a>
             {% endif %}
           </header>
+
           <div class="step-text">
             {{ content }} {% include next-step.html %}
           </div>
+
         </div>
-        <div class="col-sm-5">
+        <div class="col-md-4">
           <div class="page-diagram">
             {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" />
+            {% endif %}
             {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
+            {% endif %}
           </div>
         </div>
       </div>

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -1,68 +1,70 @@
 <!DOCTYPE html>
 <html>
-  {% include head.html %}
-  <body data-spy="scroll" data-target="#subnav">
-    {% include header.html %}
-    <div class="instructions-wrapper container-fluid">
-      <div class="row">
-        <div id="off-canvas-sidebar" class="col-md-2">
-          {% include stepsidebar500mm.html %}
-        </div>
-        <div class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3">
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
-              <a href="{{ site.baseurl }}/500mm/">500mm</a>
-              {% if page.parent%} 
-                &#47; {{ page.parent }} 
-              {% endif %} 
-              &#47;
-              <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-            
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %}
+{% include head.html %}
 
-            {% if page.grabcad_url1 %}
-              <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
-                <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
-              </a>
-              {% if page.z-axis == true %}
-              <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
+<body data-spy="scroll" data-target="#subnav">
+  {% include header.html %}
+  <div class="instructions-wrapper container-fluid">
+    <div class="row">
+      <div id="off-canvas-sidebar" class="col-md-2">
+        {% include stepsidebar500mm.html %}
+      </div>
+      <div class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
+            <a href="{{ site.baseurl }}/500mm/">500mm</a>
+            {% if page.parent%}
+            &#47; {{ page.parent }}
             {% endif %}
-
-            {% if page.grabcad_url2 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
-              <i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}
-            </a>
-            {% endif %}
-          </header>
-
-          <div class="step-text">
-            {{ content }} {% include next-step.html %}
+            &#47;
+            <span class="current-page">
+              {% if page.title %} {{ page.title }} {% endif %}
+            </span>
           </div>
+          <h1 class="step-title">{{ page.title }}</h1>
 
-        </div>
-        <div class="col-md-4">
-          <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" />
-            {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
-            {% endif %}
+          {% if page.time_estimate %}
+          <div class="time-estimate">
+            <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
           </div>
+          {% endif %}
+
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
+            <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
+          </a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
+            <i class="fa fa-cube"></i> GrabCAD Model of
+            {{ page.grabcad_name2 }}
+          </a>
+          {% endif %}
+        </header>
+
+        <div class="step-text">
+          {{ content }} {% include next-step.html %}
+        </div>
+
+      </div>
+      <div class="col-md-4">
+        <div class="page-diagram col-md-4">
+          {% if page.diagram %}
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
+          {% endif %}
+          {% if page.diagram2 %}
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
+          {% endif %}
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -16,7 +16,7 @@
         >
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
+              <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
               <a href="{{ site.baseurl }}/500mm/">500mm</a> {% if page.parent %}
               &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">

--- a/_layouts/default500mm.html
+++ b/_layouts/default500mm.html
@@ -1,73 +1,65 @@
 <!DOCTYPE html>
 <html>
+  {% include head.html %}
 
-{% include head.html %}
+  <body data-spy="scroll" data-target="#subnav">
+    {% include header.html %}
 
-<body data-spy="scroll" data-target="#subnav">
+    <div class="instructions-wrapper container-fluid">
+      <div class="row">
+        <div id="off-canvas-sidebar" class="col-md-2">
+          {% include stepsidebar500mm.html %}
+        </div>
 
-  {% include header.html %}
+        <div
+          class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
+        >
+          <header class="post-header">
+            <div class="instruction-breadcrumbs">
+              <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
+              <a href="{{ site.baseurl }}/500mm/">500mm</a> {% if page.parent %}
+              &#47; {{ page.parent }} {% endif %} &#47;
+              <span class="current-page">
+                {% if page.title %} {{ page.title }} {% endif %}
+              </span>
+            </div>
+            <h1 class="step-title">{{ page.title }}</h1>
 
-  <div class="instructions-wrapper container">
-    <div id="off-canvas-sidebar">
-      {% include stepnav500mm.html %}
-      <a id="close" href="#"><i class="fa fa-times"></i></a>
-    </div>
-    <div class="row topic-nav">
-      {% include stepnav500mm.html %}
-    </div>
-    <div class="row">
-      <div class="page-content js-instruction-step col-sm-7">
-        <header class="post-header">
-          <div class="instruction-breadcrumbs">
-            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/500mm/">500mm</a>
-            {% if page.parent %}
-            &#47;
-            {{ page.parent }}
+            {% if page.time-estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad_url1 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url1 }}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad_url2 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url2 }}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-            &#47;
-            <span class="current-page">
-              {% if page.title %}
-              {{ page.title }}
-              {% endif %}
-            </span>
+          </header>
+          <div class="step-text">
+            {{ content }} {% include next-step.html %}
           </div>
-          <h1 class="step-title">{{ page.title }}</h1>
-
-          {% if page.time-estimate %}
-          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-          {% endif %}
-
-          {% if page.grabcad_url1 %}
-          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name1}}</a>
-          {% if page.z-axis == true %}
-          <span class="grabcad-note">(You're only building part of this now)</span>
-          {% endif %}
-          {% endif %}
-          {% if page.grabcad_url2 %}
-          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name2}}</a>
-          {% endif %}
-
-        </header>
-        <div class="step-text">
-          {{ content }}
-          {% include next-step.html %}
         </div>
-      </div>
-      <div class="col-sm-5">
-        <div class="page-diagram">
-          {% if page.diagram %}
-          <img src="{{ page.diagram | prepend: site.baseurl }}" />
-          {% endif %}
-          {% if page.diagram2 %}
-          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
-          {% endif %}
+        <div class="col-sm-5">
+          <div class="page-diagram">
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  {% include scripts.html %}
-</body>
-
+    {% include scripts.html %}
+  </body>
 </html>

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -1,70 +1,70 @@
 <!DOCTYPE html>
 <html>
-  {% include head.html %}
-  <body data-spy="scroll" data-target="#subnav">
-    {% include header.html %}
-    <div class="instructions-wrapper container-fluid">
-      <div class="row">
-        <div id="off-canvas-sidebar" class="col-md-2">
-          {% include stepsidebar750mm.html %}
-        </div>
-        <div
-          class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
-          >
-          <header class="post-header">
-            <div class="instruction-breadcrumbs">
-              <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
-              <a href="{{ site.baseurl }}/750mm/">750mm</a>
-              {% if page.parent%} 
-                &#47; {{ page.parent }} 
-              {% endif %} 
-              &#47;
-              <span class="current-page">
-                {% if page.title %} {{ page.title }} {% endif %}
-              </span>
-            </div>
-            <h1 class="step-title">{{ page.title }}</h1>
-            
-            {% if page.time_estimate %}
-            <div class="time-estimate">
-              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
-            </div>
-            {% endif %}
+{% include head.html %}
 
-            {% if page.grabcad_url1 %}
-              <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
-                <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
-              </a>
-              {% if page.z-axis == true %}
-              <span class="grabcad-note">(You're only building part of this now)</span>
-              {% endif %}
+<body data-spy="scroll" data-target="#subnav">
+  {% include header.html %}
+  <div class="instructions-wrapper container-fluid">
+    <div class="row">
+      <div id="off-canvas-sidebar" class="col-md-2">
+        {% include stepsidebar750mm.html %}
+      </div>
+      <div class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3">
+        <header class="post-header">
+          <div class="instruction-breadcrumbs">
+            <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
+            <a href="{{ site.baseurl }}/750mm/">750mm</a>
+            {% if page.parent%}
+            &#47; {{ page.parent }}
             {% endif %}
-
-            {% if page.grabcad_url2 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
-              <i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}
-            </a>
-            {% endif %}
-          </header>
-
-          <div class="step-text">
-            {{ content }} {% include next-step.html %}
+            &#47;
+            <span class="current-page">
+              {% if page.title %} {{ page.title }} {% endif %}
+            </span>
           </div>
+          <h1 class="step-title">{{ page.title }}</h1>
 
-        </div>
-        <div class="col-md-4">
-          <div class="page-diagram">
-            {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" />
-            {% endif %}
-            {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
-            {% endif %}
+          {% if page.time_estimate %}
+          <div class="time-estimate">
+            <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
           </div>
+          {% endif %}
+
+          {% if page.grabcad_url1 %}
+          <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
+            <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
+          </a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
+          {% endif %}
+
+          {% if page.grabcad_url2 %}
+          <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
+            <i class="fa fa-cube"></i> GrabCAD Model of
+            {{ page.grabcad_name2 }}
+          </a>
+          {% endif %}
+        </header>
+
+        <div class="step-text">
+          {{ content }} {% include next-step.html %}
+        </div>
+
+      </div>
+      <div class="col-md-4">
+        <div class="page-diagram col-md-4">
+          {% if page.diagram %}
+          <img src="{{ page.diagram | prepend: site.baseurl }}" />
+          {% endif %}
+          {% if page.diagram2 %}
+          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
+          {% endif %}
         </div>
       </div>
     </div>
-    {% include scripts.html %}
-  </body>
+  </div>
+  {% include scripts.html %}
+</body>
+
 </html>

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -1,10 +1,8 @@
 <!DOCTYPE html>
 <html>
   {% include head.html %}
-
   <body data-spy="scroll" data-target="#subnav">
     {% include header.html %}
-
     <div class="instructions-wrapper container-fluid">
       <div class="row">
         <div id="off-canvas-sidebar" class="col-md-2">
@@ -12,49 +10,57 @@
         </div>
         <div
           class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
-        >
+          >
           <header class="post-header">
             <div class="instruction-breadcrumbs">
               <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
-              <a href="{{ site.baseurl }}/750mm/">750mm</a> {% if page.parent %}
-              &#47; {{ page.parent }} {% endif %} &#47;
+              <a href="{{ site.baseurl }}/750mm/">750mm</a>
+              {% if page.parent%} 
+                &#47; {{ page.parent }} 
+              {% endif %} 
+              &#47;
               <span class="current-page">
                 {% if page.title %} {{ page.title }} {% endif %}
               </span>
             </div>
             <h1 class="step-title">{{ page.title }}</h1>
-
-            {% if page.time-estimate %}
+            
+            {% if page.time_estimate %}
             <div class="time-estimate">
               <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
             </div>
-            {% endif %} {% if page.grabcad_url1 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url1 }}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name1 }}</a
-            >
-            {% if page.z-axis == true %}
-            <span class="grabcad-note"
-              >(You're only building part of this now)</span
-            >
-            {% endif %} {% endif %} {% if page.grabcad_url2 %}
-            <a class="grabcad-link" href="{{ page.grabcad_url2 }}"
-              ><i class="fa fa-cube"></i> GrabCAD Model of
-              {{ page.grabcad_name2 }}</a
-            >
+            {% endif %}
+
+            {% if page.grabcad_url1 %}
+              <a class="grabcad-link" href="{{ page.grabcad_url1 }}">
+                <i class="fa fa-cube"></i> GrabCAD Model of {{ page.grabcad_name1 }}
+              </a>
+              {% if page.z-axis == true %}
+              <span class="grabcad-note">(You're only building part of this now)</span>
+              {% endif %}
+            {% endif %}
+
+            {% if page.grabcad_url2 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url2 }}">
+              <i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}
+            </a>
             {% endif %}
           </header>
+
           <div class="step-text">
             {{ content }} {% include next-step.html %}
           </div>
+
         </div>
-        <div class="col-sm-5">
+        <div class="col-md-4">
           <div class="page-diagram">
             {% if page.diagram %}
-            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" />
+            {% endif %}
             {% if page.diagram2 %}
-            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
-            %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
+            {% endif %}
           </div>
         </div>
       </div>

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -15,7 +15,7 @@
         >
           <header class="post-header">
             <div class="instruction-breadcrumbs">
-              <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
+              <a href="{{ site.url }}">X-Carve Instructions</a> &#47;
               <a href="{{ site.baseurl }}/750mm/">750mm</a> {% if page.parent %}
               &#47; {{ page.parent }} {% endif %} &#47;
               <span class="current-page">

--- a/_layouts/default750mm.html
+++ b/_layouts/default750mm.html
@@ -1,73 +1,64 @@
 <!DOCTYPE html>
 <html>
+  {% include head.html %}
 
-{% include head.html %}
+  <body data-spy="scroll" data-target="#subnav">
+    {% include header.html %}
 
-<body data-spy="scroll" data-target="#subnav">
+    <div class="instructions-wrapper container-fluid">
+      <div class="row">
+        <div id="off-canvas-sidebar" class="col-md-2">
+          {% include stepsidebar750mm.html %}
+        </div>
+        <div
+          class="page-content js-instruction-step col-sm-12 col-md-6 pl-md-3"
+        >
+          <header class="post-header">
+            <div class="instruction-breadcrumbs">
+              <a href="{{ site.baseurl }}">X-Carve Instructions</a> &#47;
+              <a href="{{ site.baseurl }}/750mm/">750mm</a> {% if page.parent %}
+              &#47; {{ page.parent }} {% endif %} &#47;
+              <span class="current-page">
+                {% if page.title %} {{ page.title }} {% endif %}
+              </span>
+            </div>
+            <h1 class="step-title">{{ page.title }}</h1>
 
-  {% include header.html %}
-
-  <div class="instructions-wrapper container">
-    <div id="off-canvas-sidebar">
-      {% include stepnav750mm.html %}
-      <a id="close" href="#"><i class="fa fa-times"></i></a>
-    </div>
-    <div class="row topic-nav">
-      {% include stepnav750mm.html %}
-    </div>
-    <div class="row">
-      <div class="page-content js-instruction-step col-sm-7">
-        <header class="post-header">
-          <div class="instruction-breadcrumbs">
-            <a href="{{site.baseurl}}">X-Carve Instructions</a> &#47; <a href="{{site.baseurl}}/750mm/">750mm</a>
-            {% if page.parent %}
-            &#47;
-            {{ page.parent }}
+            {% if page.time-estimate %}
+            <div class="time-estimate">
+              <i class="fa fa-clock-o"></i>{{ page.time_estimate }} minutes
+            </div>
+            {% endif %} {% if page.grabcad_url1 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url1 }}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name1 }}</a
+            >
+            {% if page.z-axis == true %}
+            <span class="grabcad-note"
+              >(You're only building part of this now)</span
+            >
+            {% endif %} {% endif %} {% if page.grabcad_url2 %}
+            <a class="grabcad-link" href="{{ page.grabcad_url2 }}"
+              ><i class="fa fa-cube"></i> GrabCAD Model of
+              {{ page.grabcad_name2 }}</a
+            >
             {% endif %}
-            &#47;
-            <span class="current-page">
-              {% if page.title %}
-              {{ page.title }}
-              {% endif %}
-            </span>
+          </header>
+          <div class="step-text">
+            {{ content }} {% include next-step.html %}
           </div>
-          <h1 class="step-title">{{ page.title }}</h1>
-
-          {% if page.time-estimate %}
-          <div class="time-estimate"><i class="fa fa-clock-o"></i>{{page.time_estimate}} minutes</div>
-          {% endif %}
-
-          {% if page.grabcad_url1 %}
-          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name1}}</a>
-          {% if page.z-axis == true %}
-          <span class="grabcad-note">(You're only building part of this now)</span>
-          {% endif %}
-          {% endif %}
-          {% if page.grabcad_url2 %}
-          <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name2}}</a>
-          {% endif %}
-
-        </header>
-        <div class="step-text">
-          {{ content }}
-          {% include next-step.html %}
         </div>
-      </div>
-      <div class="col-sm-5">
-        <div class="page-diagram">
-          {% if page.diagram %}
-          <img src="{{ page.diagram | prepend: site.baseurl }}" />
-          {% endif %}
-          {% if page.diagram2 %}
-          <img src="{{ page.diagram2 | prepend: site.baseurl }}" />
-          {% endif %}
+        <div class="col-sm-5">
+          <div class="page-diagram">
+            {% if page.diagram %}
+            <img src="{{ page.diagram | prepend: site.baseurl }}" /> {% endif %}
+            {% if page.diagram2 %}
+            <img src="{{ page.diagram2 | prepend: site.baseurl }}" /> {% endif
+            %}
+          </div>
         </div>
       </div>
     </div>
-  </div>
-  {% include scripts.html %}
-</body>
-
+    {% include scripts.html %}
+  </body>
 </html>

--- a/_layouts/defaultupgrade.html
+++ b/_layouts/defaultupgrade.html
@@ -38,11 +38,12 @@
           {% endif %}
 
           {% if page.grabcad_url1 %}
-          <a class="grabcad-link" href="{{page.grabcad_url1}}"><i class="fa fa-cube"></i> GrabCAD Model of
-            {{page.grabcad_name1}}</a>
-          {% if page.z-axis == true %}
-          <span class="grabcad-note">(You're only building part of this now)</span>
-          {% endif %}
+            <a class="grabcad-link" href="{{page.grabcad_url1}}">
+              <i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}
+            </a>
+            {% if page.z-axis == true %}
+            <span class="grabcad-note">(You're only building part of this now)</span>
+            {% endif %}
           {% endif %}
           {% if page.grabcad_url2 %}
           <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
@@ -55,7 +56,7 @@
           {% include next-step.html %}
         </div>
       </div>
-      <div class="col-sm-5">
+      <div class="col-md-4">
         <div class="page-diagram">
           {% if page.diagram %}
           <img src="{{ page.diagram | prepend: site.baseurl }}" />

--- a/_layouts/defaultupgrade.html
+++ b/_layouts/defaultupgrade.html
@@ -56,8 +56,8 @@
           {% include next-step.html %}
         </div>
       </div>
-      <div class="col-md-4">
-        <div class="page-diagram col-md-4">
+      <div class="col-sm-5">
+        <div class="page-diagram">
           {% if page.diagram %}
           <img src="{{ page.diagram | prepend: site.baseurl }}" />
           {% endif %}

--- a/_layouts/defaultupgrade.html
+++ b/_layouts/defaultupgrade.html
@@ -38,12 +38,12 @@
           {% endif %}
 
           {% if page.grabcad_url1 %}
-            <a class="grabcad-link" href="{{page.grabcad_url1}}">
-              <i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}
-            </a>
-            {% if page.z-axis == true %}
-            <span class="grabcad-note">(You're only building part of this now)</span>
-            {% endif %}
+          <a class="grabcad-link" href="{{page.grabcad_url1}}">
+            <i class="fa fa-cube"></i> GrabCAD Model of {{page.grabcad_name1}}
+          </a>
+          {% if page.z-axis == true %}
+          <span class="grabcad-note">(You're only building part of this now)</span>
+          {% endif %}
           {% endif %}
           {% if page.grabcad_url2 %}
           <a class="grabcad-link" href="{{page.grabcad_url2}}"><i class="fa fa-cube"></i> GrabCAD Model of
@@ -57,7 +57,7 @@
         </div>
       </div>
       <div class="col-md-4">
-        <div class="page-diagram">
+        <div class="page-diagram col-md-4">
           {% if page.diagram %}
           <img src="{{ page.diagram | prepend: site.baseurl }}" />
           {% endif %}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -75,7 +75,7 @@ body {
     font-weight: 300;
     background-color: #fff;
     -webkit-text-size-adjust: 100%;
-    font-size: 16px;
+    font-size: 18px;
     line-height: 150%;
     position: relative;
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -52,6 +52,10 @@ b, strong {
     }
 }
 
+ul {
+    list-style-position: inside;
+}
+
 /**
  * Reset some basic elements
  */

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -71,7 +71,7 @@ body {
     font-weight: 300;
     background-color: #fff;
     -webkit-text-size-adjust: 100%;
-    font-size: 20px;
+    font-size: 16px;
     line-height: 150%;
     position: relative;
 }

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -28,7 +28,7 @@
 
 #drive-rod-accordion {
   .panel-heading {
-    color:#fff;
+    color: #fff;
     background: #6b4e40;
   }
 }
@@ -111,42 +111,42 @@
   letter-spacing: 2px;
   position: relative;
   display: inline-block;
-  background: #4990E2;
+  background: #4990e2;
   color: #fff;
-  border: 2px solid #4990E2;
+  border: 2px solid #4990e2;
   text-shadow: none;
   box-shadow: none;
   padding: 12px 16px;
   font-weight: 400;
-  transition: border 0.3s ease,
-              color 0.3s ease,
-              background 0.3s ease;
-  &:hover, &:focus {
+  transition: border 0.3s ease, color 0.3s ease, background 0.3s ease;
+
+  &:hover,
+  &:focus {
     text-decoration: none;
-    color: #4990E2;
-    border-color: #4990E2;
-    background: #FFF;
+    color: #4990e2;
+    border-color: #4990e2;
+    background: #fff;
     opacity: 1;
   }
 }
 
 .btn-animate-arrow {
   &:after {
-    content: "\279E";
+    content: '\279E';
     opacity: 0;
-    transition: opacity 0.3s,
-                margin 0.3s;
+    transition: opacity 0.3s, margin 0.3s;
     padding: 0;
     margin-left: -1em;
   }
+
   &:hover:after {
     opacity: 1;
     margin-left: 0.3em;
-    content: "\279E";
+    content: '\279E';
   }
 }
 
-@media (max-width:1220px) {
+@media (max-width: 1220px) {
   iframe {
     width: 100%;
   }
@@ -161,8 +161,9 @@
   right: 20px;
   top: 5px;
 
-  .fa-plus, .fa-minus {
-    transition: display .5s ease;
+  .fa-plus,
+  .fa-minus {
+    transition: display 0.5s ease;
   }
 
   .fa-minus {
@@ -191,10 +192,10 @@
 
 .step-card {
   border: 1px solid #c8c8c8;
-  box-shadow: 2px 2px 2px rgba(0,0,0,.1);
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.1);
   padding: 20px;
 
-  &~& {
+  & ~ & {
     margin-top: 20px;
   }
 
@@ -236,20 +237,20 @@
     height: 50px;
 
     &.active {
-        border-bottom: 4px solid #383838;
+      border-bottom: 4px solid #383838;
 
-        a {
-          color: #383838;
-        }
-
-        &:hover {
-          border-color: #4990e2;
-        }
-
-        .dropdown-menu {
-          margin-top: 4px;
-        }
+      a {
+        color: #383838;
       }
+
+      &:hover {
+        border-color: #4990e2;
+      }
+
+      .dropdown-menu {
+        margin-top: 4px;
+      }
+    }
 
     a {
       border-bottom: 0;
@@ -286,7 +287,8 @@
 .container--welcome {
   padding-top: 30px;
 
-  h1, h3 {
+  h1,
+  h3 {
     text-align: center;
   }
 
@@ -306,13 +308,12 @@
     margin-top: 2em;
   }
 }
+
 .page-diagram {
   position: fixed;
-  margin-left: 10px;
-  
-  img {
-    width: 400px;
-    height: 400px;
+  margin-top: 10px;
+
+  .img-fluid {
     margin-bottom: 20px;
   }
 }

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -1,3 +1,9 @@
+.panel-title {
+  padding: 10px;
+  margin: 0;
+  cursor: pointer;
+}
+
 #motor-accordion {
   .panel-heading {
     background: #cc3440;

--- a/_sass/_components.scss
+++ b/_sass/_components.scss
@@ -1,6 +1,7 @@
 .panel-title {
   padding: 10px;
   margin: 0;
+  font-size: 16px;
   cursor: pointer;
 }
 

--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -26,8 +26,10 @@
 }
 
 .step-title {
-  margin-bottom: 6px;
+  margin-top: 10px;
+  margin-bottom: 4px;
   color: #222 !important;
+  font-size: 50px;
 }
 
 .time-estimate {
@@ -40,10 +42,6 @@
     position: relative;
     top: 3px;
   }
-}
-
-.step-title {
-  font-size: 50px;
 }
 
 .step-text {

--- a/_sass/_content.scss
+++ b/_sass/_content.scss
@@ -18,7 +18,7 @@
 }
 
 .page-content {
-  padding: 30px 0;
+  padding: 20px 0 60px;
 
   @media (max-width: 768px) {
     padding-bottom: 30px;
@@ -62,7 +62,7 @@ table {
   font-size: 16px;
   line-height: 130%;
   border-collapse: collapse;
-  box-shadow: 1px 1px 2px rgba(0,0,0,.2);
+  box-shadow: 1px 1px 2px rgba(0, 0, 0, 0.2);
   margin-bottom: 15px;
   width: 100%;
 
@@ -89,10 +89,11 @@ table {
   border: 2px solid #4990e2;
   margin-right: 20px;
   margin-top: 8px;
-  transition: background .3s ease,
-              color .3s ease;
+  transition: background 0.3s ease, color 0.3s ease;
 
-  &:hover, &:focus, &:active {
+  &:hover,
+  &:focus,
+  &:active {
     background: #fff;
     color: #4990e2;
     opacity: 1;

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -311,59 +311,43 @@ header {
   display: none;
 }
 
-#flagship-nav li a {
-  font-weight: 400;
-  text-transform: uppercase;
-  color: #666;
-  margin: 0 10px;
-  letter-spacing: 2px;
-  font-size: 12px;
-  border-radius: 0;
-  border-bottom: 0;
-}
-
-#flagship-nav li:last-of-type a {
-  margin-right: 0;
-}
-
-#flagship-nav li:first-of-type a {
-  padding-left: 0;
-}
-
 #flagship-nav {
-  margin-left: 10px;
-}
-
-#flagship-nav li a:hover {
-  background: transparent;
-  color: #4990e2 !important;
-}
-
-#flagship-nav li {
-  border-right: 1px solid #eee;
-}
-
-#flagship-nav li:last-of-type {
-  border-right: none;
-}
-
-@media (max-width: 960px) {
-  #flagship-nav {
-    margin-left: 5px;
-  }
-
-  #flagship-nav li a {
-    margin-right: 3px;
+  li a {
+    font-weight: 400;
+    text-transform: uppercase;
+    color: #666;
+    margin: 0 10px;
+    letter-spacing: 2px;
     font-size: 12px;
+    border-radius: 0;
+    border-bottom: 0;
+  }
+
+  li:last-of-type a {
+    margin-right: 0;
+  }
+
+  li:first-of-type a {
+    padding-left: 0;
+  }
+
+  li a:hover {
+    background: transparent;
+    color: #4990e2 !important;
+  }
+
+  li:last-of-type {
+    border-right: none;
+  }
+
+  @media (min-width: 992px) {
+    margin-right: 80px;
+    li {
+      border-right: 1px solid #eee;
+    }
   }
 }
 
-@media (max-width: 820px) {
-  #flagship-nav {
-    clear: left;
-    margin-left: 0;
-  }
-}
 
 .github-link {
   position: relative;
@@ -392,5 +376,27 @@ header {
     margin-right: 8px;
     line-height: 11px;
     vertical-align: middle;
+  }
+}
+.github-corner:hover .octo-arm {
+  animation: octocat-wave 560ms ease-in-out;
+}
+@media (max-width: 575px) {
+  .github-corner {
+    display: none;
+  }
+}
+@keyframes octocat-wave {
+  0%,
+  100% {
+    transform: rotate(0);
+  }
+  20%,
+  60% {
+    transform: rotate(-25deg);
+  }
+  40%,
+  80% {
+    transform: rotate(10deg);
   }
 }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -302,7 +302,7 @@ header {
 }
 
 .instructions-menu-label {
-  @media (min-width: 992px) {
+  @media (min-width: 767px) {
     display:none;
   }
 }
@@ -341,7 +341,7 @@ header {
   }
 
   @media (min-width: 992px) {
-    margin-right: 80px;
+    margin-left: 80px;
     li {
       border-right: 1px solid #eee;
     }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -1,12 +1,13 @@
-html, body {
-    font-family: 'Open Sans';
+html,
+body {
+  font-family: 'Open Sans';
 }
 
 header {
-    box-shadow: none !important;
-    border-bottom: 1px solid #eee;
-    padding-bottom: 0;
-    padding-bottom: 14px;
+  box-shadow: none !important;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 0;
+  padding-bottom: 14px;
 }
 
 .top-nav {
@@ -27,6 +28,9 @@ header {
 }
 
 .navbar-expand-lg {
+  #site-logo {
+    max-width: 200px;
+  }
   background: none;
   border: none;
   border-radius: 0;
@@ -38,163 +42,175 @@ header {
 }
 
 .search-container {
-    display: none;
+  display: none;
 }
 
 .inventables-navbar-container {
-    box-shadow: 0 2px 4px -1px rgba(0,0,0,0.25);
-    padding: 5px 0;
-    background-color: #fafafa;
-    z-index: 100000;
-    margin-bottom: 1px;
-    z-index: 999;
+  box-shadow: 0 2px 4px -1px rgba(0, 0, 0, 0.25);
+  padding: 5px 0;
+  background-color: #fafafa;
+  z-index: 100000;
+  margin-bottom: 1px;
+  z-index: 999;
 }
 
 .inventables-navbar-container .nav-pills.pull-right > li:last-of-type > a {
-    padding-right: 0 !important;
+  padding-right: 0 !important;
 }
 
 #site-text-logo {
-    font-size: 2em;
-    font-weight: 500;
-    color: #333;
-    line-height: normal;
+  font-size: 2em;
+  font-weight: 500;
+  color: #333;
+  line-height: normal;
 }
+
 .inventables-navbar-container .invent-collapse-nav {
-    margin-top: -2px !important;
-    margin-bottom: -5px;
-    margin-left: 10px;
+  margin-top: -2px !important;
+  margin-bottom: -5px;
+  margin-left: 10px;
 }
+
 .inventables-navbar-container .invent-collapse-nav > li {
-    display:inline;
+  display: inline;
 }
+
 .inventables-navbar-container .invent-collapse-nav .nav-collapse > ul > li {
-    display:inline-block;
-    margin-left: 15px;
+  display: inline-block;
+  margin-left: 15px;
 }
-.inventables-navbar-container .invent-collapse-nav .nav-collapse > ul > li:first-of-type {
-    margin-left: -5px;
+
+.inventables-navbar-container
+.invent-collapse-nav
+.nav-collapse
+> ul
+> li:first-of-type {
+  margin-left: -5px;
 }
-.inventables-navbar-container a[data-toggle="collapse"] {
-    display: none;
+
+.inventables-navbar-container a[data-toggle='collapse'] {
+  display: none;
 }
+
 .inventables-navbar-container .circle {
-    display: inline-block;
-    width: 25px;
-    height: 25px;
-    line-height: 25px;
-    background-color: #3399CB;
-    color: #fff!important;
-    text-align: center;
-    -webkit-border-radius: 15px;
-    -moz-border-radius: 15px;
-    -ms-border-radius: 15px;
-    border-radius: 15px;
-    font-size: .8em;
-    margin-top: -4px;
-    margin-bottom: -3px;
-    margin-left: 5px;
-    transition: background-color 0.5s;
-    -webkit-transition: background-color 0.5s;
+  display: inline-block;
+  width: 25px;
+  height: 25px;
+  line-height: 25px;
+  background-color: #3399cb;
+  color: #fff !important;
+  text-align: center;
+  -webkit-border-radius: 15px;
+  -moz-border-radius: 15px;
+  -ms-border-radius: 15px;
+  border-radius: 15px;
+  font-size: 0.8em;
+  margin-top: -4px;
+  margin-bottom: -3px;
+  margin-left: 5px;
+  transition: background-color 0.5s;
+  -webkit-transition: background-color 0.5s;
 }
 
 .inventables-navbar-container .nav-collapse.collapse > li {
-    display: inline-block;
+  display: inline-block;
 }
 
 .inventables-navbar-container .dropdown-menu {
-    z-index: 10000;
-    top: 150%;
-    bottom: auto;
-    width: auto;
-    min-width: 180px;
-    right: -5px;
-    left: auto;
-    background-color: #ffffff;
-border: 1px solid #ccc;
-border: 1px solid rgba(0,0,0,0.2);
--webkit-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
--moz-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
-box-shadow: 0 5px 10px rgba(0,0,0,0.2);
--webkit-background-clip: padding-box;
--moz-background-clip: padding;
-background-clip: padding-box;
-padding-top: 10px;
-padding-bottom: 10px;
-}
-.inventables-navbar-container .dropdown-menu:before {
-position: absolute;
-top: -7px;
-left: 9px;
-display: inline-block;
-border-right: 7px solid transparent;
-border-bottom: 7px solid #ccc;
-border-left: 7px solid transparent;
-border-bottom-color: rgba(0,0,0,0.2);
-content: '';
-    right: 13px;
-    left: auto;
-}
-.inventables-navbar-container .dropdown-menu:after {
-position: absolute;
-top: -6px;
-left: 10px;
-display: inline-block;
-border-right: 6px solid transparent;
-border-bottom: 6px solid #fff;
-border-left: 6px solid transparent;
-content: '';
-    right: 14px;
-    left: auto;
+  z-index: 10000;
+  top: 150%;
+  bottom: auto;
+  width: auto;
+  min-width: 180px;
+  right: -5px;
+  left: auto;
+  background-color: #fff;
+  border: 1px solid #ccc;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  -webkit-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -moz-box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
+  -webkit-background-clip: padding-box;
+  -moz-background-clip: padding;
+  background-clip: padding-box;
+  padding-top: 10px;
+  padding-bottom: 10px;
 }
 
+.inventables-navbar-container .dropdown-menu:before {
+  position: absolute;
+  top: -7px;
+  left: 9px;
+  display: inline-block;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #ccc;
+  border-left: 7px solid transparent;
+  border-bottom-color: rgba(0, 0, 0, 0.2);
+  content: '';
+  right: 13px;
+  left: auto;
+}
+
+.inventables-navbar-container .dropdown-menu:after {
+  position: absolute;
+  top: -6px;
+  left: 10px;
+  display: inline-block;
+  border-right: 6px solid transparent;
+  border-bottom: 6px solid #fff;
+  border-left: 6px solid transparent;
+  content: '';
+  right: 14px;
+  left: auto;
+}
 
 .inventables-navbar-container .dropdown-menu > li > a {
-    font-family: 'Open Sans';
-    display: block;
-    padding: 3px 20px;
-    clear: both;
-    font-weight: normal;
-    line-height: 20px;
-    color: #333333 !important;
-    white-space: nowrap;
-    line-height: 20px;
+  font-family: 'Open Sans';
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 20px;
+  color: #333 !important;
+  white-space: nowrap;
+  line-height: 20px;
 }
+
 .inventables-navbar-container .dropdown-menu > li > a:hover {
-    color: #ffffff !important;
-    text-decoration: none;
-    background-color: #0081c2 !important;
-    transition: all 0.1s;
+  color: #fff !important;
+  text-decoration: none;
+  background-color: #0081c2 !important;
+  transition: all 0.1s;
 }
 
 .inventables-navbar-container li.divider {
-height: 1px;
-margin: 9px 1px;
-overflow: hidden;
-background-color: #e5e5e5;
-border-bottom: 1px solid #fff;
+  height: 1px;
+  margin: 9px 1px;
+  overflow: hidden;
+  background-color: #e5e5e5;
+  border-bottom: 1px solid #fff;
 }
 
 #current-user {
-    display: none;
+  display: none;
 }
 
 .ember-view.login-button[title='Log In'] {
-    display: none;
+  display: none;
 }
 
 #cart-menu-item {
-    margin-right: 10px;
+  margin-right: 10px;
 }
 
 .nav-icon {
   width: 22px;
   height: 22px;
-  transition: opacity .3s ease;
+  transition: opacity 0.3s ease;
 }
 
 .nav-icon:hover {
-  opacity:.7;
+  opacity: 0.7;
 }
 
 .admin-icon {
@@ -216,11 +232,11 @@ border-bottom: 1px solid #fff;
 }
 
 .badge-cart {
-  background: #4990E2;
+  background: #4990e2;
 }
 
 .badge-notify {
-  background: #DF534F;
+  background: #df534f;
 }
 
 .user-nav {
@@ -257,81 +273,91 @@ border-bottom: 1px solid #fff;
 }
 
 .inventables-navbar-container .dropdown-toggle {
-    float: none;
+  float: none;
 }
 
 #inventables-category-outer {
   padding: 11px 20px 3px;
   font-size: 13px;
 }
+
 #inventables-category-outer li {
-    margin-right: 14px;
+  margin-right: 14px;
 }
 
 #inventables-category-outer li a {
-      color: #676767 !important;
+  color: #676767 !important;
 }
+
 #inventables-category-outer li:hover a {
-      color: #4990E2 !important;
+  color: #4990e2 !important;
 }
+
 .alert-s3-deprecation {
-    display: none;
+  display: none;
 }
+
 .badge-wrapper {
-    font-weight: normal;
+  font-weight: normal;
 }
 
 // Hide search icon
 #inventables-navbar li.user-nav-item:first-of-type {
-    display:none;
+  display: none;
 }
+
 #flagship-nav li a {
-    font-weight: 400;
-    text-transform: uppercase;
-    color: #666;
-    margin-top: 2px;
-    margin-right: 5px;
-    letter-spacing: 2px;
-    font-size: 12px;
-    border-radius: 0;
-    border-bottom: 0;
+  font-weight: 400;
+  text-transform: uppercase;
+  color: #666;
+  margin: 0 10px;
+  letter-spacing: 2px;
+  font-size: 12px;
+  border-radius: 0;
+  border-bottom: 0;
 }
+
 #flagship-nav li:last-of-type a {
-    margin-right: 0;
+  margin-right: 0;
 }
 
 #flagship-nav li:first-of-type a {
-    padding-left: 0;
+  padding-left: 0;
 }
-
 
 #flagship-nav {
-    margin-left: 10px;
+  margin-left: 10px;
 }
+
 #flagship-nav li a:hover {
-    background: transparent;
-    color: #4990e2 !important;
+  background: transparent;
+  color: #4990e2 !important;
 }
+
 #flagship-nav li {
-    border-right: 1px solid #eee;
+  border-right: 1px solid #eee;
 }
+
 #flagship-nav li:last-of-type {
-    border-right: none;
+  border-right: none;
 }
+
 @media (max-width: 960px) {
-    #flagship-nav {
-        margin-left: 5px;
-    }
-    #flagship-nav li a {
-        margin-right: 3px;
-        font-size: 12px;
-    }
+  #flagship-nav {
+    margin-left: 5px;
+  }
+
+  #flagship-nav li a {
+    margin-right: 3px;
+    font-size: 12px;
+  }
 }
+
 @media (max-width: 820px) {
-    #flagship-nav {
-        clear: left;
-        margin-left: 0;
-    }
+  #flagship-nav {
+    clear: left;
+    margin-left: 0;
+  }
 }
 
 .github-link {
@@ -348,9 +374,11 @@ border-bottom: 1px solid #fff;
   transition: box-shadow .3s ease;
   letter-spacing: 0 !important;
 
-  &:hover, &:focus, &:active {
+  &:hover,
+  &:focus,
+  &:active {
     opacity: 1;
-    box-shadow: 2px 2px 2px rgba(0,0,0,.2);
+    box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.2);
     background: #fff !important;
     border: 1px solid #4990e2 !important;
   }

--- a/_sass/_header.scss
+++ b/_sass/_header.scss
@@ -28,8 +28,8 @@ header {
 }
 
 .navbar-expand-lg {
-  #site-logo {
-    max-width: 200px;
+  a {
+    border-bottom: none;
   }
   background: none;
   border: none;
@@ -301,6 +301,11 @@ header {
   font-weight: normal;
 }
 
+.instructions-menu-label {
+  @media (min-width: 992px) {
+    display:none;
+  }
+}
 // Hide search icon
 #inventables-navbar li.user-nav-item:first-of-type {
   display: none;
@@ -368,11 +373,10 @@ header {
   background: #fff;
   color: #4990e2 !important;
   text-transform: none !important;
-  top: 6px;
-  left: 10px;
   box-shadow: 2px 2px 2px rgba(0,0,0,.1);
   transition: box-shadow .3s ease;
   letter-spacing: 0 !important;
+  white-space: nowrap;
 
   &:hover,
   &:focus,
@@ -388,10 +392,5 @@ header {
     margin-right: 8px;
     line-height: 11px;
     vertical-align: middle;
-  }
-
-  @media (max-width: 768px) {
-    top: 0 !important;
-    left: 0 !important;
   }
 }

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -1,36 +1,3 @@
-.sidebar {
-  padding-top: 30px;
-  border-right: 1px solid #ddd;
-
-  @media (max-width: 768px) {
-    display: none;
-  }
-
-  .nav {
-    margin-left: 0;
-
-    .nav-item a.active {
-      color: #4990e2;
-    }
-
-    & > li > a {
-      color: #383838;
-      border-bottom: 1px solid transparent;
-      font-size: 16px;
-      padding: 5px 5px 5px 0;
-
-      &:first-of-type {
-        padding-top: 0;
-      }
-
-      &:hover, &:focus {
-        background: none;
-        border-bottom: 1px solid #eee;
-      }
-    }
-  }
-}
-
 #hamburger {
   display: none;
   text-decoration: none !important;
@@ -53,46 +20,53 @@
 }
 
 #off-canvas-sidebar {
-  display: block;
-  visibility: hidden;
-  -webkit-transform: translate3d(-100%, 0, 0);
-  transform: translateX(-100%, 0, 0);
-  position: absolute;
-  border-right: none;
-  left: 0;
-  z-index: 100;
-  width: 100%;
-  height: auto;
-  -webkit-transition: all 0.5s;
-  transition: all 0.5s;
-  background: #4990e2;
-  box-shadow: 4px 2px 4px rgba(0,0,0,.4);
+  font-size: 16px;
+  padding: 0;
 
-  a { 
-    color: #fff;
+  @media (min-width: 767px) {
+    border-right: 1px solid rgba(0, 0, 0, 0.1);
+  }
 
-    &:hover, &:focus, &:active {
-      background: transparent;
+  .sidebar {
+    @supports (position: sticky) {
+      position: sticky;
+      top: 1em;
+      margin-top: 1em;
+    }
+
+    @supports not (position: sticky) {
+      position: fixed;
     }
   }
 
-  #close {
-    position: absolute;
-    top: 10px;
-    right: 10px;
-    font-size: 40px;
+  .nav-item .active {
+    color: #222;
   }
-}
 
-#off-canvas-sidebar.open {
-  visibility: visible;
-  -webkit-transform: translateX(0);
-  transform: translateX(0);
+  ul {
+    font-weight: 600;
+    list-style: none;
+  }
 
-  @media (min-width: 768px) {
-    visibility: hidden;
-    -webkit-transform: translate3d(-100%, 0, 0);
-    transform: translateX(-100%, 0, 0);
+  ol {
+    list-style-position: inside;
+    font-size: 14px;
+    font-weight: 400;
+
+    a {
+      color: #999;
+    }
+  }
+
+  a {
+    color: #555;
+    border-bottom: none;
+
+    &:hover,
+    &:focus,
+    &:active {
+      background: transparent;
+    }
   }
 }
 
@@ -132,7 +106,7 @@
   border-bottom: 1px solid #eee;
 
   h4 {
-    margin-bottom: 0px;
+    margin-bottom: 0;
     color: #222;
     font-size: 16px;
     border-bottom: 1px solid #eee;

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -39,9 +39,16 @@
     }
   }
 
-  .nav-item .active {
-    color: #222;
-    font-weight: 600;
+  .nav-item {
+    margin: 10px 0;
+    &.active, .active {
+      color: #222;
+      font-weight: 600;
+    }
+  }
+
+  .subnav-item {
+    margin: 5px 0;
   }
 
   ul {
@@ -53,6 +60,7 @@
     list-style-position: inside;
     font-size: 14px;
     font-weight: 300;
+    margin-left: 6px;
 
     a {
       color: #999;

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -27,7 +27,7 @@
     border-right: 1px solid rgba(0, 0, 0, 0.1);
   }
 
-  .sidebar {
+  .navbar {
     @supports (position: sticky) {
       position: sticky;
       top: 1em;
@@ -61,10 +61,6 @@
     font-size: 14px;
     font-weight: 300;
     margin-left: 6px;
-
-    a {
-      color: #999;
-    }
   }
 
   a {

--- a/_sass/_sidebar.scss
+++ b/_sass/_sidebar.scss
@@ -41,17 +41,18 @@
 
   .nav-item .active {
     color: #222;
+    font-weight: 600;
   }
 
   ul {
-    font-weight: 600;
+    font-weight: 400;
     list-style: none;
   }
 
   ol {
     list-style-position: inside;
     font-size: 14px;
-    font-weight: 400;
+    font-weight: 300;
 
     a {
       color: #999;

--- a/js/sidebar.js
+++ b/js/sidebar.js
@@ -1,12 +1,12 @@
-$(document).ready(function() {
+$(document).ready(function () {
 
   var sidebar = $("#off-canvas-sidebar");
 
-  $("#hamburger").click(function() {
+  $("#hamburger").click(function () {
     sidebar.addClass('open');
   });
 
-  $("#close").click(function() {
+  $("#close").click(function () {
     sidebar.removeClass('open');
   });
 });


### PR DESCRIPTION
#### This PR:
- Make instructions more mobile friendly
- Adds mobile menu
- Changed Github contribution link
- Added a lovely side bar. In all of our layouts, we had a sidebar nav that was hidden at all time. I did a little work to make that constantly visible, presentable and functional, and it now replaces the top nav.
- Makes breadcrumbs work
- Left `2015` and `upgrade` layout alone

TODO: Clean up old sidebar, make nav and other things dynamic, update 2015 and upgrade layouts

#### Before
![image](https://user-images.githubusercontent.com/10836887/50309233-b9622080-0463-11e9-9f86-8457b07549c0.png)

#### After
![image](https://user-images.githubusercontent.com/10836887/50309144-45277d00-0463-11e9-86ba-af7901c2c648.png)
