### PR TITLE
Removing links to Carvey page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -17,9 +17,6 @@
             <a href="https://www.inventables.com/technologies/x-carve">X-Carve</a>
           </li>
           <li>
-            <a href="https://www.inventables.com/technologies/carvey">Carvey</a>
-          </li>
-          <li>
             <a href="https://www.inventables.com/technologies/easel">Easel</a>
           </li>
           <li><a href="https://www.inventables.com/projects">Projects</a></li>

--- a/accessories/e-stop-with-enclosure/index.html
+++ b/accessories/e-stop-with-enclosure/index.html
@@ -50,7 +50,6 @@
       </ul>
       <ul class="nav navbar-nav nav-pills pull-left" id="flagship-nav">
         <li><a href="https://www.inventables.com/technologies/x-carve">X-Carve</a></li>
-        <li><a href="https://www.inventables.com/technologies/carvey">Carvey</a></li>
         <li><a href="https://www.inventables.com/technologies/easel">Easel</a></li>
         <li><a href="https://www.inventables.com/projects">Projects</a></li>
         <li><a href="https://www.inventables.com/forum">Forum</a></li>


### PR DESCRIPTION
In conjunction with https://github.com/inventables/fbolt/pull/2739
Pivotal Card: https://www.pivotaltracker.com/story/show/164959793

<img width="828" alt="Screen Shot 2019-03-28 at 11 30 39 AM" src="https://user-images.githubusercontent.com/10836887/55175269-fc135300-514c-11e9-85cf-e43fc8707ca1.png">
<img width="422" alt="Screen Shot 2019-03-28 at 11 30 48 AM" src="https://user-images.githubusercontent.com/10836887/55175271-fc135300-514c-11e9-8d98-5d14560c46a9.png">
